### PR TITLE
fix: relay readLoop race condition + hardening

### DIFF
--- a/internal/nostr/relay.go
+++ b/internal/nostr/relay.go
@@ -194,7 +194,10 @@ func (r *Relay) connect(ctx context.Context) error {
 	r.connected = true
 
 	// Start the read loop in a goroutine.
-	go r.readLoop()
+	// Pass conn and ctx as parameters — capturing from local scope while lock
+	// is held eliminates the race where close() nils r.conn before readLoop
+	// can acquire the lock to capture it.
+	go r.readLoop(conn, r.ctx)
 
 	return nil
 }
@@ -217,13 +220,13 @@ func (r *Relay) send(ctx context.Context, msg []byte) error {
 // readLoop processes incoming messages from the relay.
 // Nostr relays send: ["EVENT", sub_id, event], ["EOSE", sub_id],
 // ["OK", event_id, success, message], ["NOTICE", message].
-func (r *Relay) readLoop() {
-	// Capture conn under the lock — close() may nil r.conn concurrently.
-	r.mu.Lock()
-	conn := r.conn
-	ctx := r.ctx
-	r.mu.Unlock()
-
+//
+// conn and ctx are passed as parameters (not captured from r.conn) to prevent
+// a race condition: close() can nil r.conn between connect()'s Unlock and
+// readLoop's Lock, causing a nil pointer panic. By accepting them as args
+// from connect()'s local scope (while the lock is still held), we guarantee
+// they are never nil.
+func (r *Relay) readLoop(conn *websocket.Conn, ctx context.Context) {
 	defer func() {
 		r.mu.Lock()
 		r.connected = false

--- a/internal/nostr/relay.go
+++ b/internal/nostr/relay.go
@@ -229,7 +229,13 @@ func (r *Relay) send(ctx context.Context, msg []byte) error {
 func (r *Relay) readLoop(conn *websocket.Conn, ctx context.Context) {
 	defer func() {
 		r.mu.Lock()
-		r.connected = false
+		// Only update state if this goroutine still owns the active connection.
+		// Without this check, a stale readLoop from a previous connection could
+		// mark a freshly-reconnected relay as disconnected.
+		if r.conn == conn {
+			r.connected = false
+			r.conn = nil
+		}
 		r.mu.Unlock()
 	}()
 
@@ -304,7 +310,7 @@ func (r *Relay) handleMessage(data []byte) {
 			if !success {
 				var reason string
 				json.Unmarshal(msg[3], &reason)
-				log.Printf("[relay] event %s rejected by %s: %s", eventID[:8], r.URL, reason)
+				log.Printf("[relay] event %s rejected by %s: %s", truncateID(eventID), r.URL, reason)
 			}
 		}
 
@@ -315,6 +321,15 @@ func (r *Relay) handleMessage(data []byte) {
 			log.Printf("[relay] NOTICE from %s: %s", r.URL, notice)
 		}
 	}
+}
+
+// truncateID safely shortens an event ID for logging.
+// Prevents panics from malicious relays sending short IDs.
+func truncateID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
 }
 
 func (r *Relay) close() {

--- a/internal/nostr/relay_test.go
+++ b/internal/nostr/relay_test.go
@@ -364,3 +364,73 @@ func TestRelayPool_PublishToDisconnectedRelay(t *testing.T) {
 		t.Errorf("expected 1 accepting relay, got %d", accepted)
 	}
 }
+
+func TestRelayPool_ImmediateCloseNoPanic(t *testing.T) {
+	// Regression: close() racing with readLoop startup must not panic.
+	// Reproduces the CI nil-pointer crash by connecting and immediately closing
+	// many times under the race detector.
+	for i := 0; i < 50; i++ {
+		mr := newMockRelay()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		pool := NewRelayPool([]string{mr.wsURL()})
+
+		if err := pool.Connect(ctx); err != nil {
+			cancel()
+			mr.close()
+			t.Fatalf("iteration %d: Connect: %v", i, err)
+		}
+
+		// Immediately close — exercises the race window.
+		pool.Close()
+		cancel()
+		mr.close()
+	}
+}
+
+func TestRelayPool_ShortOKEventID(t *testing.T) {
+	// STRIDE: Tampering — relay sends an OK with a short event ID.
+	// Must not panic on eventID[:8].
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "done")
+		ctx := r.Context()
+
+		// Wait for an EVENT, then send OK with a short ID.
+		_, _, err = conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		conn.Write(ctx, websocket.MessageText, []byte(`["OK","bad",false,"rejected"]`))
+
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	pool := NewRelayPool([]string{wsURL})
+	if err := pool.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer pool.Close()
+
+	kp, _ := GenerateKeyPair()
+	event := &Event{
+		CreatedAt: time.Now().Unix(),
+		Kind:      1,
+		Tags:      Tags{},
+		Content:   "test",
+	}
+	event.Sign(kp)
+
+	pool.Publish(ctx, event)
+
+	// Give time for the short-ID OK to be processed without panicking.
+	time.Sleep(300 * time.Millisecond)
+}


### PR DESCRIPTION
## Bug

CI panicked with nil pointer dereference in `readLoop()` after Phase 2 merge:

```
panic: runtime error: invalid memory address or nil pointer dereference
nhooyr.io/websocket.(*Conn).reader(0x0, ...)
  relay.go:234
```

## Root Cause

Race between `connect()` and `close()`: the `readLoop` goroutine re-acquired `r.mu` to capture `r.conn`, but `close()` could nil it first. Linux goroutine scheduling on CI triggered the race window that macOS didn't.

## Fixes (GPT rubber-duck validated)

| Fix | What | Why |
|-----|------|-----|
| **Race elimination** | Pass `conn`/`ctx` as `readLoop` parameters from `connect()`'s local scope | Structurally impossible for `close()` to nil the values |
| **Connection ownership** | `readLoop` defer checks `r.conn == conn` before marking disconnected | Prevents stale goroutine from marking a freshly-reconnected relay as offline |
| **Short eventID panic** | Added `truncateID()` for `eventID[:8]` in OK handler | Malicious relay sending short OK IDs could crash the client |

## New Tests

- `TestRelayPool_ImmediateCloseNoPanic`: 50-iteration connect/close stress test under race detector
- `TestRelayPool_ShortOKEventID`: malicious short-ID regression test

**70 tests pass** with `-race -count=1`.