### PR TITLE
Phase 4: Chaumian ecash blind signatures for buyer-session unlinkability

### DIFF
--- a/.notes/decisions.md
+++ b/.notes/decisions.md
@@ -1543,3 +1543,185 @@ RetryFailedPayouts reuses same row (MarkPayoutRetrying), so UNIQUE is compatible
 go.mod marked it indirect, which can confuse tooling and go mod tidy.
 
 **Decision:** Moved to direct require block. Matches actual usage pattern.
+
+---
+
+## Phase 4 — Blind Signatures
+
+---
+
+### Decision 65: RSA blind signatures via cryptoballot/rsablind
+
+**Context:** Need Chaumian ecash-style unlinkability for bandwidth tokens.
+Hub signs blinded messages without seeing the token secret, preventing
+buyer-session linkage.
+
+**Decision:** Full-Domain-Hash RSA blind signatures using cryptoballot/rsablind
+(2048-bit RSA, 1536-bit FDH). Not production-audited — acceptable for PoC
+and grant applications. Production requires formal audit.
+
+**Why not Cashu NUTs?** ARFL's product is bandwidth, not ecash. Cashu
+compatibility would add complexity without benefit. We use the same
+cryptographic primitive but with our own wire format.
+
+---
+
+### Decision 66: Denomination-keyed model (key_id → bytes_per_token)
+
+**Context:** Need to encode bandwidth value into tokens without revealing it
+during signing (Hub is blind to content).
+
+**Decision:** Each RSA signing key maps to a fixed denomination via immutable
+config. key_id "key-100mb" always means 100,000,000 bytes. The mapping MUST NOT
+change after tokens are issued — changing it would alter the value of outstanding
+tokens.
+
+**Trade-off:** Less flexible than encoding denomination in the signed message,
+but simpler and avoids the need for denomination-in-message verification.
+Matches the Cashu model.
+
+---
+
+### Decision 67: System model is online bounded-risk authorization
+
+**Context:** Pure offline ecash would allow unlimited double-spending across
+nodes. Pure online ecash would require Hub connectivity for every byte.
+
+**Decision:** Hybrid model — nodes verify signatures locally (offline-capable),
+then call Hub /spend for double-spend check (online requirement). Bounded risk:
+during Hub unavailability, each token can be replayed to at most N offline nodes,
+capped at 100MB × N per token. This is explicitly stated in the architecture.
+
+**Grant narrative:** "Online bounded-risk authorization for bandwidth" — NOT
+"offline anonymous ecash." Reviewers will assume the latter unless stated.
+
+---
+
+### Decision 68: Payment preimage as /redeem authentication
+
+**Context:** Need to prove the caller paid the invoice without linking identity.
+
+**Decision:** POST /redeem requires the payment preimage. SHA256(preimage) must
+match a payment_hash with a settled entitlement. Only the payer knows the
+preimage (Lightning protocol guarantee), so this is proof-of-payment without
+identity.
+
+**Why not payment_hash?** Anyone can observe a payment_hash on the network.
+The preimage is a secret revealed only to the payer upon successful payment.
+
+---
+
+### Decision 69: Atomic entitlement consumption before signing
+
+**Context:** If signing fails after tokens are consumed, those tokens are lost.
+If tokens are consumed after signing, a crash could lead to free tokens.
+
+**Decision:** Consume first, sign second. Tokens consumed but unsigned is a
+loss scenario that requires manual remediation (contact support). Tokens signed
+but unconsumed would be free bandwidth — worse outcome. The "consume then sign"
+ordering is safer.
+
+**CRITICAL failure mode:** If signing fails after consumption, log at CRITICAL
+level and include "tokens consumed — contact support" in the error response.
+
+---
+
+### Decision 70: Nonce + request_hash idempotency for /redeem
+
+**Context:** Network failures during /redeem could cause the client to retry.
+Without idempotency, retries would consume additional tokens.
+
+**Decision:** Each redemption has a client-provided nonce. The Hub stores
+(nonce, request_hash, blind_signatures). On retry:
+- Same nonce + same request → return cached signatures (no token consumption)
+- Same nonce + different request → 409 Conflict
+
+The request_hash = SHA256(key_id + "|" + join(blinded_messages, "|")).
+
+---
+
+### Decision 71: Token ID derivation with domain separation
+
+**Context:** Token IDs must be unique across key versions, protocol versions,
+and denomination keys.
+
+**Decision:** SHA256("ARFL|v1|{key_id}|{token_secret_hex}"). The domain prefix
+prevents cross-version collisions, key_id prevents cross-denomination collisions,
+and token_secret ensures uniqueness per token.
+
+---
+
+### Decision 72: Separated /redeem from payment (two-step redemption)
+
+**Context:** The rubber-duck review identified that combining payment
+confirmation, entitlement tracking, and blind signing in one endpoint
+creates fragility.
+
+**Decision:** POST /purchase creates invoice + (on settlement) entitlement.
+POST /redeem consumes entitlement → blind-signs. Financial logic and
+cryptographic logic are isolated. The /redeem endpoint does only cryptographic
+work after the entitlement guard.
+
+---
+
+### Decision 73: /spend returns first_spend flag (not error on double-spend)
+
+**Context:** A double-spend attempt could be malicious (replay attack) or
+benign (node retrying after network failure).
+
+**Decision:** POST /spend always returns 200 with {first_spend: bool}. The
+node decides how to act: first_spend=true → serve traffic,
+first_spend=false → reject or investigate. This avoids the Hub making
+policy decisions for nodes.
+
+---
+
+### Decision 74: EnableBlindSignatures opt-in method
+
+**Context:** Phase 3 HMAC tickets and Phase 4 blind signatures must coexist.
+Not all deployments will have blind sig keys.
+
+**Decision:** PurchaseAPI.EnableBlindSignatures(mint, verifier, defaultKeyID)
+registers /redeem and /spend routes. If not called, these routes don't exist.
+The settlement listener creates entitlements only when blindMint != nil.
+
+---
+
+### Decision 75: Mock Lightning client generates preimage→hash pairs
+
+**Context:** The /redeem endpoint authenticates via SHA256(preimage) == payment_hash.
+The mock was generating random hashes without corresponding preimages.
+
+**Decision:** MockClient.CreateInvoice now generates a random 32-byte preimage,
+computes SHA256(preimage) as the payment_hash, and stores both. GetPreimage()
+returns the preimage for end-to-end testing. This properly simulates the
+Lightning payment flow.
+
+---
+
+### Decision 76: Settlement listener creates entitlements atomically
+
+**Context:** When an invoice is settled, the Hub needs to create both Phase 3
+tickets and Phase 4 entitlements.
+
+**Decision:** onInvoiceSettled creates the entitlement after ticket insertion
+(Step 6). Idempotent: if the entitlement already exists (concurrent/retry),
+the duplicate insert is caught and logged. The entitlement ID is
+"ent-{payment_hash}" for deterministic deduplication.
+
+---
+
+### Decision 77: STRIDE test coverage for blind sig paths
+
+**Context:** Grant reviewers (HRF, OpenSats) value security rigor. STRIDE
+analysis is uncommon in crypto protocol implementations.
+
+**Decision:** 14 STRIDE tests covering:
+- Spoofing: fake preimage, forged signature
+- Tampering: tampered token secret, oversized body
+- Repudiation: redemption audit trail, spent token audit trail
+- DoS: message count limit
+- Elevation: cross-key redemption, entitlement overdraw, cross-key spend
+- Concurrent: no overdraw under concurrent redeem, exactly-one first_spend
+- Info disclosure: payment hash not leaked in errors
+- Replay: nonce reuse across payments blocked

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 
 require (
 	github.com/btcsuite/btcd/chainhash/v2 v2.0.0 // indirect
+	github.com/cryptoballot/fdh v0.0.0-20170924224734-5eb31ce2010c // indirect
+	github.com/cryptoballot/rsablind v0.0.0-20170925165423-14f9913880b7 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn
 github.com/btcsuite/btcd/btcec/v2 v2.5.0/go.mod h1:+K/MYXcLBtHEQjRbjHuJChuybk4LCgjdjgRwil+e+Kk=
 github.com/btcsuite/btcd/chainhash/v2 v2.0.0 h1:PMLlSloHJuEeB80XG9EjpXWNEKAZAMLl6YHZ6YsEuoA=
 github.com/btcsuite/btcd/chainhash/v2 v2.0.0/go.mod h1:mKxcZ7oGTXE7IRV+sS9hP4EVBwc/SzfNR+52IsOP9j8=
+github.com/cryptoballot/fdh v0.0.0-20170924224734-5eb31ce2010c h1:habgwvtC2G/hgK7TUV7sPmGe43OIqAr0aKUuD4X4D7s=
+github.com/cryptoballot/fdh v0.0.0-20170924224734-5eb31ce2010c/go.mod h1:5pBX/BVsUUknnixeKb1/q20aCjY7Ig5C3LcCrwTSWoU=
+github.com/cryptoballot/rsablind v0.0.0-20170925165423-14f9913880b7 h1:zkd3AG8n/WAUxTIy5DKd22U8oQGDpbaCsaRKewdxnxQ=
+github.com/cryptoballot/rsablind v0.0.0-20170925165423-14f9913880b7/go.mod h1:Jkrm3gC2eNL7k0K6wlLehI7CHiZVUCZ/cu5xT1aDNb4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=

--- a/internal/credentials/blind.go
+++ b/internal/credentials/blind.go
@@ -1,0 +1,324 @@
+// Package credentials — blind signature support for Phase 4.
+//
+// This file implements Chaumian ecash-style RSA blind signatures for
+// bandwidth tickets. The Hub signs blinded messages without seeing the
+// token secret, making it impossible to link ticket usage back to the buyer.
+//
+// System model: online bounded-risk authorization, NOT offline ecash.
+// Nodes verify signatures locally, then check spent status with the Hub.
+//
+// Denomination model: each signing key maps to a fixed denomination
+// (bytes_per_token) via immutable config. The key_id → denomination
+// mapping MUST NOT change after tokens have been issued with that key.
+//
+// Cryptographic primitive: Full-Domain-Hash RSA Blind Signatures
+// (via cryptoballot/rsablind). Not production-audited — suitable for
+// PoC and grant applications. Production deployment requires audit.
+package credentials
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"sync"
+
+	"github.com/cryptoballot/fdh"
+	"github.com/cryptoballot/rsablind"
+)
+
+// Blind signature constants.
+const (
+	// RSAKeySize is the RSA key size in bits. 2048 is the minimum for
+	// security against Index Calculation Attacks with FDH.
+	RSAKeySize = 2048
+
+	// FDHHashSize is the Full-Domain-Hash output size in bits.
+	// Must be 3/4 of key size per rsablind recommendations.
+	FDHHashSize = 1536
+
+	// MaxBlindMessagesPerRequest limits batch size to prevent DoS.
+	MaxBlindMessagesPerRequest = 500
+
+	// BlindTokenVersion is the protocol version for token ID derivation.
+	BlindTokenVersion = 1
+)
+
+// DenominationKey is an immutable mapping from key_id to signing key
+// and denomination. Once tokens are issued with a key, the denomination
+// MUST NOT change (append-only config, never mutate).
+type DenominationKey struct {
+	KeyID         string
+	BytesPerToken int64
+	PrivateKey    *rsa.PrivateKey // nil on nodes (verifier-only)
+	PublicKey     *rsa.PublicKey
+}
+
+// BlindToken is the credential a client presents to a node.
+// The node verifies the RSA signature on TokenSecret using the Hub's
+// public key, then calls /spend for double-spend prevention.
+type BlindToken struct {
+	Version     uint8  `json:"version"`      // protocol version (1)
+	KeyID       string `json:"key_id"`       // which denomination key signed this
+	TokenSecret []byte `json:"token_secret"` // client-generated random secret
+	Signature   []byte `json:"signature"`    // RSA blind signature (unblinded)
+}
+
+// TokenID derives the canonical token identifier using domain-separated SHA256.
+// This ID is used for double-spend tracking in the spent_tokens table.
+// Format: SHA256("ARFL|v1|{key_id}|{token_secret_hex}")
+func (t *BlindToken) TokenID() string {
+	h := sha256.New()
+	h.Write([]byte(fmt.Sprintf("ARFL|v%d|%s|%s", t.Version, t.KeyID, hex.EncodeToString(t.TokenSecret))))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// --- Mint (Hub-side: signs blinded messages) ---
+
+// BlindMint signs blinded messages from clients.
+// The Hub holds the RSA private key; it never sees the token secrets.
+type BlindMint interface {
+	// SignBlinded signs a batch of blinded messages.
+	// Returns one signature per message, or an error.
+	SignBlinded(keyID string, blindedMessages [][]byte) ([][]byte, error)
+
+	// PublicKeyBytes returns the DER-encoded public key for a given key_id.
+	// Nodes need this to verify token signatures.
+	PublicKeyBytes(keyID string) ([]byte, error)
+
+	// Denomination returns the bytes_per_token for a given key_id.
+	Denomination(keyID string) (int64, error)
+}
+
+// RSABlindMint implements BlindMint using Full-Domain-Hash RSA blind signatures.
+type RSABlindMint struct {
+	keys map[string]*DenominationKey
+	mu   sync.RWMutex
+}
+
+// NewRSABlindMint creates a mint with one or more denomination keys.
+func NewRSABlindMint(keys []*DenominationKey) *RSABlindMint {
+	m := &RSABlindMint{keys: make(map[string]*DenominationKey, len(keys))}
+	for _, k := range keys {
+		m.keys[k.KeyID] = k
+	}
+	return m
+}
+
+// SignBlinded signs a batch of blinded messages with the specified key.
+func (m *RSABlindMint) SignBlinded(keyID string, blindedMessages [][]byte) ([][]byte, error) {
+	if len(blindedMessages) == 0 {
+		return nil, fmt.Errorf("no blinded messages provided")
+	}
+	if len(blindedMessages) > MaxBlindMessagesPerRequest {
+		return nil, fmt.Errorf("too many messages: %d exceeds max %d", len(blindedMessages), MaxBlindMessagesPerRequest)
+	}
+
+	m.mu.RLock()
+	key, ok := m.keys[keyID]
+	m.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("unknown key_id: %s", keyID)
+	}
+	if key.PrivateKey == nil {
+		return nil, fmt.Errorf("key %s has no private key (verifier-only)", keyID)
+	}
+
+	sigs := make([][]byte, len(blindedMessages))
+	for i, bm := range blindedMessages {
+		sig, err := rsablind.BlindSign(key.PrivateKey, bm)
+		if err != nil {
+			return nil, fmt.Errorf("blind sign message %d: %w", i, err)
+		}
+		sigs[i] = sig
+	}
+
+	return sigs, nil
+}
+
+// PublicKeyBytes returns the DER-encoded public key for distribution to nodes.
+func (m *RSABlindMint) PublicKeyBytes(keyID string) ([]byte, error) {
+	m.mu.RLock()
+	key, ok := m.keys[keyID]
+	m.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("unknown key_id: %s", keyID)
+	}
+	return x509.MarshalPKIXPublicKey(key.PublicKey)
+}
+
+// Denomination returns the bytes_per_token for a key_id.
+func (m *RSABlindMint) Denomination(keyID string) (int64, error) {
+	m.mu.RLock()
+	key, ok := m.keys[keyID]
+	m.mu.RUnlock()
+
+	if !ok {
+		return 0, fmt.Errorf("unknown key_id: %s", keyID)
+	}
+	return key.BytesPerToken, nil
+}
+
+// --- Verifier (Node-side: verifies token signatures) ---
+
+// BlindVerifier verifies RSA blind signatures on tokens.
+// Nodes hold the Hub's public key(s) and verify locally.
+type BlindVerifier interface {
+	// Verify checks that the token's signature is valid for its TokenSecret
+	// under the specified key_id.
+	Verify(token *BlindToken) error
+
+	// Denomination returns the bytes_per_token for a key_id.
+	Denomination(keyID string) (int64, error)
+}
+
+// RSABlindVerifier implements BlindVerifier.
+type RSABlindVerifier struct {
+	keys map[string]*DenominationKey // key_id → public key + denomination
+	mu   sync.RWMutex
+}
+
+// NewRSABlindVerifier creates a verifier with the given denomination keys.
+// Only public keys are needed (PrivateKey should be nil).
+func NewRSABlindVerifier(keys []*DenominationKey) *RSABlindVerifier {
+	v := &RSABlindVerifier{keys: make(map[string]*DenominationKey, len(keys))}
+	for _, k := range keys {
+		v.keys[k.KeyID] = k
+	}
+	return v
+}
+
+// Verify checks the blind signature on a token.
+func (v *RSABlindVerifier) Verify(token *BlindToken) error {
+	if token == nil {
+		return ErrInvalidTicket
+	}
+	if token.Version != BlindTokenVersion {
+		return fmt.Errorf("%w: unsupported version %d", ErrInvalidTicket, token.Version)
+	}
+	if token.KeyID == "" {
+		return fmt.Errorf("%w: empty key_id", ErrInvalidTicket)
+	}
+	if len(token.TokenSecret) == 0 {
+		return fmt.Errorf("%w: empty token secret", ErrInvalidTicket)
+	}
+	if len(token.Signature) == 0 {
+		return fmt.Errorf("%w: empty signature", ErrInvalidTicket)
+	}
+
+	v.mu.RLock()
+	key, ok := v.keys[token.KeyID]
+	v.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownKeyID, token.KeyID)
+	}
+
+	// Hash the token secret using Full-Domain-Hash (same as client-side blinding).
+	hashed := fdh.Sum(crypto.SHA256, FDHHashSize, token.TokenSecret)
+
+	// Verify the unblinded signature against the hashed token secret.
+	if err := rsablind.VerifyBlindSignature(key.PublicKey, hashed, token.Signature); err != nil {
+		return ErrInvalidMAC // reuse existing error — "MAC" covers both HMAC and blind sigs
+	}
+
+	return nil
+}
+
+// Denomination returns the bytes_per_token for a key_id.
+func (v *RSABlindVerifier) Denomination(keyID string) (int64, error) {
+	v.mu.RLock()
+	key, ok := v.keys[keyID]
+	v.mu.RUnlock()
+
+	if !ok {
+		return 0, fmt.Errorf("unknown key_id: %s", keyID)
+	}
+	return key.BytesPerToken, nil
+}
+
+// AddKey registers a new denomination key (rotation support).
+func (v *RSABlindVerifier) AddKey(key *DenominationKey) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.keys[key.KeyID] = key
+}
+
+// --- Client-side helpers (for arfl-client) ---
+
+// BlindedMessage holds the blinded message and the unblinding factor.
+// The client keeps the unblinder secret; the Hub never sees it.
+type BlindedMessage struct {
+	Blinded   []byte // sent to Hub for blind signing
+	Unblinder []byte // kept by client for unblinding
+}
+
+// BlindTokenSecret blinds a token secret for signing by the Hub.
+func BlindTokenSecret(pubKey *rsa.PublicKey, tokenSecret []byte) (*BlindedMessage, error) {
+	hashed := fdh.Sum(crypto.SHA256, FDHHashSize, tokenSecret)
+
+	blinded, unblinder, err := rsablind.Blind(pubKey, hashed)
+	if err != nil {
+		return nil, fmt.Errorf("blind token: %w", err)
+	}
+
+	return &BlindedMessage{
+		Blinded:   blinded,
+		Unblinder: unblinder,
+	}, nil
+}
+
+// UnblindSignature removes the blinding factor from a blind signature.
+func UnblindSignature(pubKey *rsa.PublicKey, blindSig []byte, unblinder []byte) []byte {
+	return rsablind.Unblind(pubKey, blindSig, unblinder)
+}
+
+// GenerateTokenSecret creates a cryptographically random 32-byte token secret.
+func GenerateTokenSecret() ([]byte, error) {
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, fmt.Errorf("generate token secret: %w", err)
+	}
+	return secret, nil
+}
+
+// GenerateDenominationKey creates a new RSA key pair for a denomination.
+func GenerateDenominationKey(keyID string, bytesPerToken int64) (*DenominationKey, error) {
+	if keyID == "" {
+		return nil, fmt.Errorf("key_id must not be empty")
+	}
+	if bytesPerToken <= 0 {
+		return nil, fmt.Errorf("bytes_per_token must be positive")
+	}
+
+	privKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("generate RSA key: %w", err)
+	}
+
+	return &DenominationKey{
+		KeyID:         keyID,
+		BytesPerToken: bytesPerToken,
+		PrivateKey:    privKey,
+		PublicKey:     &privKey.PublicKey,
+	}, nil
+}
+
+// PublicKeyFromDER parses a DER-encoded public key.
+// Used by nodes to load the Hub's public key from config or Nostr.
+func PublicKeyFromDER(der []byte) (*rsa.PublicKey, error) {
+	pub, err := x509.ParsePKIXPublicKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA public key")
+	}
+	return rsaPub, nil
+}

--- a/internal/credentials/blind_test.go
+++ b/internal/credentials/blind_test.go
@@ -1,0 +1,525 @@
+package credentials
+
+import (
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// --- Key generation ---
+
+func TestGenerateDenominationKey(t *testing.T) {
+	key, err := GenerateDenominationKey("key-100mb", 100_000_000)
+	if err != nil {
+		t.Fatalf("GenerateDenominationKey: %v", err)
+	}
+	if key.KeyID != "key-100mb" {
+		t.Errorf("KeyID = %q, want %q", key.KeyID, "key-100mb")
+	}
+	if key.BytesPerToken != 100_000_000 {
+		t.Errorf("BytesPerToken = %d, want %d", key.BytesPerToken, 100_000_000)
+	}
+	if key.PrivateKey == nil {
+		t.Fatal("PrivateKey should not be nil")
+	}
+	if key.PublicKey == nil {
+		t.Fatal("PublicKey should not be nil")
+	}
+	if key.PrivateKey.N.BitLen() < RSAKeySize {
+		t.Errorf("key size %d bits, want >= %d", key.PrivateKey.N.BitLen(), RSAKeySize)
+	}
+}
+
+func TestGenerateDenominationKey_EmptyID(t *testing.T) {
+	_, err := GenerateDenominationKey("", 100_000_000)
+	if err == nil {
+		t.Fatal("expected error for empty key_id")
+	}
+}
+
+func TestGenerateDenominationKey_ZeroBytes(t *testing.T) {
+	_, err := GenerateDenominationKey("key-1", 0)
+	if err == nil {
+		t.Fatal("expected error for zero bytes_per_token")
+	}
+}
+
+// --- Full blind signature flow ---
+
+func TestBlindSignature_FullFlow(t *testing.T) {
+	// 1. Generate denomination key (Hub).
+	denomKey, err := GenerateDenominationKey("key-100mb", 100_000_000)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	// 2. Create mint (Hub-side).
+	mint := NewRSABlindMint([]*DenominationKey{denomKey})
+
+	// 3. Create verifier (Node-side, public key only).
+	verifier := NewRSABlindVerifier([]*DenominationKey{{
+		KeyID:         denomKey.KeyID,
+		BytesPerToken: denomKey.BytesPerToken,
+		PublicKey:     denomKey.PublicKey,
+	}})
+
+	// 4. Client generates token secret.
+	tokenSecret, err := GenerateTokenSecret()
+	if err != nil {
+		t.Fatalf("generate secret: %v", err)
+	}
+
+	// 5. Client blinds the token secret.
+	bm, err := BlindTokenSecret(denomKey.PublicKey, tokenSecret)
+	if err != nil {
+		t.Fatalf("blind: %v", err)
+	}
+
+	// 6. Hub signs the blinded message (blind — doesn't see tokenSecret).
+	blindSigs, err := mint.SignBlinded("key-100mb", [][]byte{bm.Blinded})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if len(blindSigs) != 1 {
+		t.Fatalf("got %d sigs, want 1", len(blindSigs))
+	}
+
+	// 7. Client unblinds the signature.
+	sig := UnblindSignature(denomKey.PublicKey, blindSigs[0], bm.Unblinder)
+
+	// 8. Create the blind token.
+	token := &BlindToken{
+		Version:     BlindTokenVersion,
+		KeyID:       "key-100mb",
+		TokenSecret: tokenSecret,
+		Signature:   sig,
+	}
+
+	// 9. Node verifies the token.
+	if err := verifier.Verify(token); err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	// 10. Verify denomination lookup.
+	denom, err := verifier.Denomination("key-100mb")
+	if err != nil {
+		t.Fatalf("denomination: %v", err)
+	}
+	if denom != 100_000_000 {
+		t.Errorf("denomination = %d, want 100_000_000", denom)
+	}
+}
+
+// --- Batch signing ---
+
+func TestBlindSignature_BatchFlow(t *testing.T) {
+	denomKey, _ := GenerateDenominationKey("key-batch", 100_000_000)
+	mint := NewRSABlindMint([]*DenominationKey{denomKey})
+	verifier := NewRSABlindVerifier([]*DenominationKey{{
+		KeyID: denomKey.KeyID, BytesPerToken: denomKey.BytesPerToken,
+		PublicKey: denomKey.PublicKey,
+	}})
+
+	count := 10
+	secrets := make([][]byte, count)
+	blindMsgs := make([][]byte, count)
+	unblinderMap := make(map[int]*BlindedMessage, count)
+
+	for i := 0; i < count; i++ {
+		secret, _ := GenerateTokenSecret()
+		secrets[i] = secret
+		bm, err := BlindTokenSecret(denomKey.PublicKey, secret)
+		if err != nil {
+			t.Fatalf("blind %d: %v", i, err)
+		}
+		blindMsgs[i] = bm.Blinded
+		unblinderMap[i] = bm
+	}
+
+	blindSigs, err := mint.SignBlinded("key-batch", blindMsgs)
+	if err != nil {
+		t.Fatalf("batch sign: %v", err)
+	}
+	if len(blindSigs) != count {
+		t.Fatalf("got %d sigs, want %d", len(blindSigs), count)
+	}
+
+	for i := 0; i < count; i++ {
+		sig := UnblindSignature(denomKey.PublicKey, blindSigs[i], unblinderMap[i].Unblinder)
+		token := &BlindToken{
+			Version: BlindTokenVersion, KeyID: "key-batch",
+			TokenSecret: secrets[i], Signature: sig,
+		}
+		if err := verifier.Verify(token); err != nil {
+			t.Errorf("token %d verify failed: %v", i, err)
+		}
+	}
+}
+
+// --- Token ID derivation ---
+
+func TestTokenID_Deterministic(t *testing.T) {
+	token := &BlindToken{
+		Version:     BlindTokenVersion,
+		KeyID:       "key-1",
+		TokenSecret: []byte("test-secret"),
+	}
+
+	id1 := token.TokenID()
+	id2 := token.TokenID()
+	if id1 != id2 {
+		t.Fatalf("TokenID not deterministic: %s != %s", id1, id2)
+	}
+	if len(id1) != 64 { // SHA256 hex
+		t.Errorf("TokenID length = %d, want 64", len(id1))
+	}
+}
+
+func TestTokenID_DomainSeparation(t *testing.T) {
+	// Same secret, different key_id → different token ID.
+	secret := []byte("same-secret")
+	t1 := &BlindToken{Version: 1, KeyID: "key-a", TokenSecret: secret}
+	t2 := &BlindToken{Version: 1, KeyID: "key-b", TokenSecret: secret}
+
+	if t1.TokenID() == t2.TokenID() {
+		t.Fatal("different key_id must produce different token IDs")
+	}
+}
+
+func TestTokenID_MatchesManualComputation(t *testing.T) {
+	token := &BlindToken{
+		Version:     1,
+		KeyID:       "key-1",
+		TokenSecret: []byte{0xab, 0xcd},
+	}
+	expected := sha256.Sum256([]byte("ARFL|v1|key-1|abcd"))
+	if token.TokenID() != hex.EncodeToString(expected[:]) {
+		t.Fatal("TokenID doesn't match manual computation")
+	}
+}
+
+// --- Verification failures ---
+
+func TestBlindVerifier_WrongSignature(t *testing.T) {
+	denomKey, _ := GenerateDenominationKey("key-1", 100_000_000)
+	verifier := NewRSABlindVerifier([]*DenominationKey{{
+		KeyID: denomKey.KeyID, BytesPerToken: denomKey.BytesPerToken,
+		PublicKey: denomKey.PublicKey,
+	}})
+
+	token := &BlindToken{
+		Version:     BlindTokenVersion,
+		KeyID:       "key-1",
+		TokenSecret: []byte("real-secret"),
+		Signature:   []byte("garbage-signature-not-valid"),
+	}
+	if err := verifier.Verify(token); err == nil {
+		t.Fatal("expected verification failure for wrong signature")
+	}
+}
+
+func TestBlindVerifier_UnknownKeyID(t *testing.T) {
+	verifier := NewRSABlindVerifier(nil)
+	token := &BlindToken{
+		Version:     BlindTokenVersion,
+		KeyID:       "nonexistent",
+		TokenSecret: []byte("secret"),
+		Signature:   []byte("sig"),
+	}
+	if err := verifier.Verify(token); err == nil {
+		t.Fatal("expected error for unknown key_id")
+	}
+}
+
+func TestBlindVerifier_EmptyToken(t *testing.T) {
+	verifier := NewRSABlindVerifier(nil)
+	if err := verifier.Verify(nil); err == nil {
+		t.Fatal("expected error for nil token")
+	}
+}
+
+func TestBlindVerifier_WrongVersion(t *testing.T) {
+	denomKey, _ := GenerateDenominationKey("key-1", 100_000_000)
+	verifier := NewRSABlindVerifier([]*DenominationKey{{
+		KeyID: denomKey.KeyID, BytesPerToken: denomKey.BytesPerToken,
+		PublicKey: denomKey.PublicKey,
+	}})
+
+	token := &BlindToken{
+		Version:     99,
+		KeyID:       "key-1",
+		TokenSecret: []byte("secret"),
+		Signature:   []byte("sig"),
+	}
+	if err := verifier.Verify(token); err == nil {
+		t.Fatal("expected error for wrong version")
+	}
+}
+
+func TestBlindVerifier_WrongKey(t *testing.T) {
+	// Sign with one key, verify with another.
+	key1, _ := GenerateDenominationKey("key-1", 100_000_000)
+	key2, _ := GenerateDenominationKey("key-2", 100_000_000)
+
+	mint := NewRSABlindMint([]*DenominationKey{key1})
+	verifier := NewRSABlindVerifier([]*DenominationKey{{
+		KeyID: "key-1", BytesPerToken: key2.BytesPerToken,
+		PublicKey: key2.PublicKey, // wrong key!
+	}})
+
+	secret, _ := GenerateTokenSecret()
+	bm, _ := BlindTokenSecret(key1.PublicKey, secret)
+	sigs, _ := mint.SignBlinded("key-1", [][]byte{bm.Blinded})
+	sig := UnblindSignature(key1.PublicKey, sigs[0], bm.Unblinder)
+
+	token := &BlindToken{
+		Version: BlindTokenVersion, KeyID: "key-1",
+		TokenSecret: secret, Signature: sig,
+	}
+	if err := verifier.Verify(token); err == nil {
+		t.Fatal("expected verification failure when verifier has wrong public key")
+	}
+}
+
+// --- Mint edge cases ---
+
+func TestMint_EmptyBatch(t *testing.T) {
+	key, _ := GenerateDenominationKey("k", 100_000_000)
+	mint := NewRSABlindMint([]*DenominationKey{key})
+
+	_, err := mint.SignBlinded("k", nil)
+	if err == nil {
+		t.Fatal("expected error for empty batch")
+	}
+}
+
+func TestMint_TooManyMessages(t *testing.T) {
+	key, _ := GenerateDenominationKey("k", 100_000_000)
+	mint := NewRSABlindMint([]*DenominationKey{key})
+
+	msgs := make([][]byte, MaxBlindMessagesPerRequest+1)
+	for i := range msgs {
+		msgs[i] = []byte("msg")
+	}
+	_, err := mint.SignBlinded("k", msgs)
+	if err == nil {
+		t.Fatal("expected error for too many messages")
+	}
+}
+
+func TestMint_UnknownKeyID(t *testing.T) {
+	mint := NewRSABlindMint(nil)
+	_, err := mint.SignBlinded("nonexistent", [][]byte{[]byte("msg")})
+	if err == nil {
+		t.Fatal("expected error for unknown key_id")
+	}
+}
+
+// --- Public key serialization ---
+
+func TestPublicKey_RoundTrip(t *testing.T) {
+	key, _ := GenerateDenominationKey("k", 100_000_000)
+	mint := NewRSABlindMint([]*DenominationKey{key})
+
+	der, err := mint.PublicKeyBytes("k")
+	if err != nil {
+		t.Fatalf("PublicKeyBytes: %v", err)
+	}
+
+	pub, err := PublicKeyFromDER(der)
+	if err != nil {
+		t.Fatalf("PublicKeyFromDER: %v", err)
+	}
+
+	if pub.N.Cmp(key.PublicKey.N) != 0 || pub.E != key.PublicKey.E {
+		t.Fatal("round-tripped key doesn't match original")
+	}
+}
+
+// --- STRIDE: Concurrent signing ---
+
+func TestSTRIDE_ConcurrentSigning(t *testing.T) {
+	key, _ := GenerateDenominationKey("k", 100_000_000)
+	mint := NewRSABlindMint([]*DenominationKey{key})
+	verifier := NewRSABlindVerifier([]*DenominationKey{{
+		KeyID: key.KeyID, BytesPerToken: key.BytesPerToken,
+		PublicKey: key.PublicKey,
+	}})
+
+	var wg sync.WaitGroup
+	errs := make([]error, 20)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			secret, _ := GenerateTokenSecret()
+			bm, err := BlindTokenSecret(key.PublicKey, secret)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			sigs, err := mint.SignBlinded("k", [][]byte{bm.Blinded})
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			sig := UnblindSignature(key.PublicKey, sigs[0], bm.Unblinder)
+			token := &BlindToken{
+				Version: BlindTokenVersion, KeyID: "k",
+				TokenSecret: secret, Signature: sig,
+			}
+			errs[idx] = verifier.Verify(token)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
+}
+
+// --- STRIDE: Token forgery ---
+
+func TestSTRIDE_CannotForgeToken(t *testing.T) {
+	key, _ := GenerateDenominationKey("k", 100_000_000)
+	verifier := NewRSABlindVerifier([]*DenominationKey{{
+		KeyID: key.KeyID, BytesPerToken: key.BytesPerToken,
+		PublicKey: key.PublicKey,
+	}})
+
+	// Try to forge a token without the private key.
+	secret, _ := GenerateTokenSecret()
+	fakeToken := &BlindToken{
+		Version:     BlindTokenVersion,
+		KeyID:       "k",
+		TokenSecret: secret,
+		Signature:   make([]byte, 256), // zeroed "signature"
+	}
+	if err := verifier.Verify(fakeToken); err == nil {
+		t.Fatal("forged token should not verify")
+	}
+}
+
+// --- STRIDE: Cross-key replay ---
+
+func TestSTRIDE_CrossKeyReplay(t *testing.T) {
+	// Token signed by key-1 should NOT verify under key-2.
+	key1, _ := GenerateDenominationKey("key-1", 100_000_000)
+	key2, _ := GenerateDenominationKey("key-2", 200_000_000)
+
+	mint := NewRSABlindMint([]*DenominationKey{key1})
+	verifier := NewRSABlindVerifier([]*DenominationKey{
+		{KeyID: "key-1", BytesPerToken: key1.BytesPerToken, PublicKey: key1.PublicKey},
+		{KeyID: "key-2", BytesPerToken: key2.BytesPerToken, PublicKey: key2.PublicKey},
+	})
+
+	secret, _ := GenerateTokenSecret()
+	bm, _ := BlindTokenSecret(key1.PublicKey, secret)
+	sigs, _ := mint.SignBlinded("key-1", [][]byte{bm.Blinded})
+	sig := UnblindSignature(key1.PublicKey, sigs[0], bm.Unblinder)
+
+	// Present token as key-2 (different denomination).
+	token := &BlindToken{
+		Version: BlindTokenVersion, KeyID: "key-2",
+		TokenSecret: secret, Signature: sig,
+	}
+	if err := verifier.Verify(token); err == nil {
+		t.Fatal("cross-key replay should fail verification")
+	}
+}
+
+// --- STRIDE: Denomination immutability ---
+
+func TestSTRIDE_DenominationConsistency(t *testing.T) {
+	key, _ := GenerateDenominationKey("k", 100_000_000)
+	mint := NewRSABlindMint([]*DenominationKey{key})
+
+	// Verify denomination is consistent.
+	d1, _ := mint.Denomination("k")
+	d2, _ := mint.Denomination("k")
+	if d1 != d2 || d1 != 100_000_000 {
+		t.Fatalf("denomination not consistent: %d, %d", d1, d2)
+	}
+}
+
+// --- Multiple denominations ---
+
+func TestMultipleDenominations(t *testing.T) {
+	key100, _ := GenerateDenominationKey("100mb", 100_000_000)
+	key256, _ := GenerateDenominationKey("256mb", 256_000_000)
+
+	mint := NewRSABlindMint([]*DenominationKey{key100, key256})
+	verifier := NewRSABlindVerifier([]*DenominationKey{
+		{KeyID: "100mb", BytesPerToken: 100_000_000, PublicKey: key100.PublicKey},
+		{KeyID: "256mb", BytesPerToken: 256_000_000, PublicKey: key256.PublicKey},
+	})
+
+	for _, tc := range []struct {
+		keyID string
+		key   *DenominationKey
+	}{
+		{"100mb", key100},
+		{"256mb", key256},
+	} {
+		secret, _ := GenerateTokenSecret()
+		bm, _ := BlindTokenSecret(tc.key.PublicKey, secret)
+		sigs, err := mint.SignBlinded(tc.keyID, [][]byte{bm.Blinded})
+		if err != nil {
+			t.Fatalf("%s: sign: %v", tc.keyID, err)
+		}
+		sig := UnblindSignature(tc.key.PublicKey, sigs[0], bm.Unblinder)
+		token := &BlindToken{
+			Version: BlindTokenVersion, KeyID: tc.keyID,
+			TokenSecret: secret, Signature: sig,
+		}
+		if err := verifier.Verify(token); err != nil {
+			t.Errorf("%s: verify failed: %v", tc.keyID, err)
+		}
+		denom, _ := verifier.Denomination(tc.keyID)
+		if (tc.keyID == "100mb" && denom != 100_000_000) ||
+			(tc.keyID == "256mb" && denom != 256_000_000) {
+			t.Errorf("%s: denomination = %d", tc.keyID, denom)
+		}
+	}
+}
+
+// --- Verifier key rotation ---
+
+func TestVerifier_AddKey(t *testing.T) {
+	key1, _ := GenerateDenominationKey("key-1", 100_000_000)
+	verifier := NewRSABlindVerifier([]*DenominationKey{{
+		KeyID: "key-1", BytesPerToken: key1.BytesPerToken,
+		PublicKey: key1.PublicKey,
+	}})
+
+	// Initially key-2 is unknown.
+	key2, _ := GenerateDenominationKey("key-2", 200_000_000)
+	if _, err := verifier.Denomination("key-2"); err == nil {
+		t.Fatal("key-2 should not exist yet")
+	}
+
+	// Add key-2.
+	verifier.AddKey(&DenominationKey{
+		KeyID: "key-2", BytesPerToken: 200_000_000,
+		PublicKey: key2.PublicKey,
+	})
+
+	denom, err := verifier.Denomination("key-2")
+	if err != nil {
+		t.Fatalf("denomination after AddKey: %v", err)
+	}
+	if denom != 200_000_000 {
+		t.Errorf("denomination = %d, want 200_000_000", denom)
+	}
+}
+
+// Helper to suppress "unused" errors for the rsa import.
+var _ *rsa.PublicKey
+
+// Helper to suppress "unused" errors for the fmt import.
+var _ = fmt.Sprintf

--- a/internal/lightning/mock.go
+++ b/internal/lightning/mock.go
@@ -3,6 +3,7 @@ package lightning
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"sync"
@@ -19,9 +20,10 @@ import (
 //   - Concurrent access from multiple goroutines
 //   - Broadcast to multiple subscribers
 type MockClient struct {
-	mu       sync.Mutex
-	invoices map[string]*Invoice // paymentHash → invoice
-	payments map[string]*PaymentResult
+	mu        sync.Mutex
+	invoices  map[string]*Invoice // paymentHash → invoice
+	preimages map[string]string   // paymentHash → preimage (hex)
+	payments  map[string]*PaymentResult
 
 	// Subscriber management — each subscriber gets its own channel.
 	subs map[chan *Invoice]struct{}
@@ -37,9 +39,10 @@ type MockClient struct {
 // NewMockClient creates a mock Lightning client.
 func NewMockClient() *MockClient {
 	return &MockClient{
-		invoices: make(map[string]*Invoice),
-		payments: make(map[string]*PaymentResult),
-		subs:     make(map[chan *Invoice]struct{}),
+		invoices:  make(map[string]*Invoice),
+		preimages: make(map[string]string),
+		payments:  make(map[string]*PaymentResult),
+		subs:      make(map[chan *Invoice]struct{}),
 	}
 }
 
@@ -52,7 +55,7 @@ func (m *MockClient) CreateInvoice(ctx context.Context, amountSats int64, memo s
 		return nil, fmt.Errorf("amount must be positive")
 	}
 
-	hash, err := randomHash()
+	hash, preimage, err := randomPreimageHash()
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +73,7 @@ func (m *MockClient) CreateInvoice(ctx context.Context, amountSats int64, memo s
 
 	m.mu.Lock()
 	m.invoices[hash] = inv
+	m.preimages[hash] = preimage
 	m.mu.Unlock()
 
 	return inv, nil
@@ -131,7 +135,7 @@ func (m *MockClient) SendPayment(ctx context.Context, paymentRequest string, amo
 		}
 	}
 
-	hash, _ := randomHash()
+	hash := randomHex()
 	result := &PaymentResult{
 		PaymentHash: hash,
 		Status:      PaymentSucceeded,
@@ -165,7 +169,7 @@ func (m *MockClient) Keysend(ctx context.Context, destPubkey string, amountSats 
 		return &copy, nil
 	}
 
-	hash, _ := randomHash()
+	hash := randomHex()
 	result := &PaymentResult{
 		PaymentHash: hash,
 		Status:      PaymentSucceeded,
@@ -234,10 +238,29 @@ func (m *MockClient) InvoiceCount() int {
 	return len(m.invoices)
 }
 
-func randomHash() (string, error) {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
+// GetPreimage returns the hex-encoded preimage for a payment hash.
+// Only the payer knows the preimage — this simulates that knowledge.
+func (m *MockClient) GetPreimage(paymentHash string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.preimages[paymentHash]
+}
+
+// randomPreimageHash generates a random 32-byte preimage and its SHA256 hash.
+// Returns (payment_hash_hex, preimage_hex, error).
+func randomPreimageHash() (string, string, error) {
+	preimage := make([]byte, 32)
+	if _, err := rand.Read(preimage); err != nil {
+		return "", "", err
 	}
-	return hex.EncodeToString(b), nil
+	hash := sha256.Sum256(preimage)
+	return hex.EncodeToString(hash[:]), hex.EncodeToString(preimage), nil
+}
+
+// randomHex generates a random 32-byte hex string (for payment IDs that
+// don't need a preimage relationship).
+func randomHex() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return hex.EncodeToString(b)
 }

--- a/internal/payments/api.go
+++ b/internal/payments/api.go
@@ -33,6 +33,7 @@ type PurchaseAPI struct {
 	// Phase 4: blind signature support (nil until EnableBlindSignatures).
 	blindMint     credentials.BlindMint
 	blindVerifier credentials.BlindVerifier
+	blindKeyID    string // default denomination key for new entitlements
 
 	// Rate limiting: map[IP][]timestamp.
 	rateLimit   map[string][]time.Time
@@ -351,6 +352,25 @@ func (api *PurchaseAPI) onInvoiceSettled(inv *lightning.Invoice) error {
 
 	log.Printf("[payment-api] issued %d tickets for invoice %s (tier %s)",
 		len(tickets), inv.PaymentHash, record.Tier)
+
+	// Step 6 (Phase 4): Create entitlement if blind signatures are enabled.
+	// The entitlement enables POST /redeem for this payment.
+	if api.blindMint != nil {
+		entID := fmt.Sprintf("ent-%s", inv.PaymentHash)
+		err := api.store.InsertEntitlement(entID, inv.PaymentHash, tier.TicketCount, tier.TicketBytes, api.blindKeyID)
+		if err != nil {
+			// Idempotency: if entitlement already exists, that's fine.
+			existing, getErr := api.store.GetEntitlementByPaymentHash(inv.PaymentHash)
+			if getErr != nil || existing == nil {
+				return fmt.Errorf("insert entitlement for %s: %w", inv.PaymentHash, err)
+			}
+			log.Printf("[payment-api] entitlement already exists for %s", inv.PaymentHash)
+		} else {
+			log.Printf("[payment-api] created entitlement for %s (key=%s, tokens=%d)",
+				inv.PaymentHash, api.blindKeyID, tier.TicketCount)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/payments/api.go
+++ b/internal/payments/api.go
@@ -30,6 +30,10 @@ type PurchaseAPI struct {
 	issuer credentials.Issuer
 	mux    *http.ServeMux
 
+	// Phase 4: blind signature support (nil until EnableBlindSignatures).
+	blindMint     credentials.BlindMint
+	blindVerifier credentials.BlindVerifier
+
 	// Rate limiting: map[IP][]timestamp.
 	rateLimit   map[string][]time.Time
 	rateMu      sync.Mutex

--- a/internal/payments/blind_api.go
+++ b/internal/payments/blind_api.go
@@ -1,0 +1,328 @@
+package payments
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/Radi-Labs/ARFL/internal/credentials"
+)
+
+// --- Blind signature request/response types (Phase 4) ---
+
+// RedeemRequest is the JSON body for POST /redeem.
+// The client proves payment via preimage and requests blind signatures.
+type RedeemRequest struct {
+	PaymentPreimage string   `json:"payment_preimage"` // hex: 32 bytes = 64 hex chars
+	KeyID           string   `json:"key_id"`           // denomination key to sign with
+	BlindedMessages []string `json:"blinded_messages"` // hex-encoded blinded messages
+	Nonce           string   `json:"nonce"`            // idempotency nonce (max 64 chars)
+}
+
+// RedeemResponse is the JSON response for POST /redeem.
+type RedeemResponse struct {
+	BlindSignatures []string `json:"blind_signatures"` // hex-encoded blind signatures
+	BytesPerToken   int64    `json:"bytes_per_token"`
+	TokensRedeemed  int      `json:"tokens_redeemed"`
+	TokensRemaining int      `json:"tokens_remaining"`
+}
+
+// SpendRequest is the JSON body for POST /spend.
+// A node submits a token for double-spend checking after local verification.
+type SpendRequest struct {
+	KeyID       string `json:"key_id"`
+	TokenSecret string `json:"token_secret"` // hex: 32 bytes
+	Signature   string `json:"signature"`    // hex: RSA unblinded signature
+	NodePubkey  string `json:"node_pubkey"`  // reporting node's public key
+}
+
+// SpendResponse is the JSON response for POST /spend.
+type SpendResponse struct {
+	FirstSpend    bool  `json:"first_spend"`
+	BytesPerToken int64 `json:"bytes_per_token"`
+}
+
+// EnableBlindSignatures registers the /redeem and /spend endpoints.
+// Call this after NewPurchaseAPI when Phase 4 blind signatures are enabled.
+func (api *PurchaseAPI) EnableBlindSignatures(mint credentials.BlindMint, verifier credentials.BlindVerifier) {
+	api.blindMint = mint
+	api.blindVerifier = verifier
+	api.mux.HandleFunc("/redeem", api.handleRedeem)
+	api.mux.HandleFunc("/spend", api.handleSpend)
+}
+
+// handleRedeem processes blind signature redemptions.
+//
+// Flow:
+//  1. Validate preimage → derive payment_hash
+//  2. Check idempotency (nonce + request_hash)
+//  3. Look up entitlement by payment_hash
+//  4. Atomically consume tokens BEFORE signing
+//  5. Blind-sign messages
+//  6. Cache redemption for crash recovery
+//
+// POST /redeem
+func (api *PurchaseAPI) handleRedeem(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Body limit: blinded messages are ~256 bytes hex each, 500 max ≈ 128KB + overhead.
+	r.Body = http.MaxBytesReader(w, r.Body, 256*1024)
+
+	var req RedeemRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// --- Validate preimage ---
+	if len(req.PaymentPreimage) != 64 {
+		jsonError(w, "payment_preimage must be 64 hex characters (32 bytes)", http.StatusBadRequest)
+		return
+	}
+	preimage, err := hex.DecodeString(req.PaymentPreimage)
+	if err != nil {
+		jsonError(w, "payment_preimage must be valid hex", http.StatusBadRequest)
+		return
+	}
+
+	// Derive payment_hash = SHA256(preimage). Only the payer knows the preimage.
+	hashBytes := sha256.Sum256(preimage)
+	paymentHash := hex.EncodeToString(hashBytes[:])
+
+	// --- Validate nonce ---
+	if req.Nonce == "" {
+		jsonError(w, "nonce is required", http.StatusBadRequest)
+		return
+	}
+	if len(req.Nonce) > 64 {
+		jsonError(w, "nonce too long (max 64 chars)", http.StatusBadRequest)
+		return
+	}
+
+	// --- Validate blinded messages ---
+	if len(req.BlindedMessages) == 0 {
+		jsonError(w, "blinded_messages must not be empty", http.StatusBadRequest)
+		return
+	}
+	if len(req.BlindedMessages) > credentials.MaxBlindMessagesPerRequest {
+		jsonError(w, fmt.Sprintf("too many messages: max %d", credentials.MaxBlindMessagesPerRequest), http.StatusBadRequest)
+		return
+	}
+
+	// --- Validate key_id ---
+	if req.KeyID == "" {
+		jsonError(w, "key_id is required", http.StatusBadRequest)
+		return
+	}
+
+	// --- Idempotency check ---
+	requestHash := computeRequestHash(req.KeyID, req.BlindedMessages)
+
+	existing, err := api.store.GetRedemption(req.Nonce)
+	if err != nil {
+		log.Printf("[blind-api] GetRedemption error: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if existing != nil {
+		if existing.RequestHash != requestHash {
+			jsonError(w, "nonce conflict: already used with different request", http.StatusConflict)
+			return
+		}
+		// Idempotent replay — return cached signatures.
+		var sigs []string
+		if err := json.Unmarshal([]byte(existing.BlindSignatures), &sigs); err != nil {
+			log.Printf("[blind-api] unmarshal cached signatures: %v", err)
+			jsonError(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		ent, err := api.store.GetEntitlementByPaymentHash(paymentHash)
+		if err != nil {
+			log.Printf("[blind-api] get entitlement for replay: %v", err)
+			jsonError(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		denom, _ := api.blindMint.Denomination(req.KeyID)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(RedeemResponse{
+			BlindSignatures: sigs,
+			BytesPerToken:   denom,
+			TokensRedeemed:  existing.TokensCount,
+			TokensRemaining: ent.TokensRemaining,
+		})
+		return
+	}
+
+	// --- Look up entitlement ---
+	ent, err := api.store.GetEntitlementByPaymentHash(paymentHash)
+	if err != nil {
+		jsonError(w, "no entitlement found for this payment", http.StatusNotFound)
+		return
+	}
+
+	// Validate key_id matches the entitlement's denomination key.
+	if ent.KeyID != req.KeyID {
+		jsonError(w, fmt.Sprintf("key_id mismatch: entitlement uses %s", ent.KeyID), http.StatusBadRequest)
+		return
+	}
+
+	// --- Decode blinded messages ---
+	blindedMsgs := make([][]byte, len(req.BlindedMessages))
+	for i, bm := range req.BlindedMessages {
+		decoded, err := hex.DecodeString(bm)
+		if err != nil {
+			jsonError(w, fmt.Sprintf("blinded_messages[%d]: invalid hex", i), http.StatusBadRequest)
+			return
+		}
+		blindedMsgs[i] = decoded
+	}
+
+	// --- Atomically consume tokens BEFORE signing ---
+	// If this fails, no signatures are issued (no risk of free tokens).
+	count := len(blindedMsgs)
+	if err := api.store.ConsumeEntitlement(ent.ID, count); err != nil {
+		jsonError(w, "insufficient tokens remaining", http.StatusPaymentRequired)
+		return
+	}
+
+	// --- Blind-sign ---
+	blindSigs, err := api.blindMint.SignBlinded(req.KeyID, blindedMsgs)
+	if err != nil {
+		// Tokens consumed but signing failed — critical bug, not client error.
+		log.Printf("[blind-api] CRITICAL: tokens consumed but signing failed for %s: %v", paymentHash, err)
+		jsonError(w, "signing failed (tokens consumed — contact support)", http.StatusInternalServerError)
+		return
+	}
+
+	// Encode signatures as hex.
+	sigStrings := make([]string, len(blindSigs))
+	for i, sig := range blindSigs {
+		sigStrings[i] = hex.EncodeToString(sig)
+	}
+
+	// --- Cache redemption for crash recovery ---
+	sigsJSON, _ := json.Marshal(sigStrings)
+	if err := api.store.InsertRedemption(req.Nonce, ent.ID, requestHash, count, string(sigsJSON)); err != nil {
+		// Tokens consumed + sigs issued — cache failure is non-fatal but log loudly.
+		log.Printf("[blind-api] WARNING: redemption cache failed for nonce %s: %v", req.Nonce, err)
+	}
+
+	// Fetch updated remaining count.
+	updatedEnt, err := api.store.GetEntitlementByPaymentHash(paymentHash)
+	remaining := 0
+	if err == nil {
+		remaining = updatedEnt.TokensRemaining
+	}
+
+	denom, _ := api.blindMint.Denomination(req.KeyID)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(RedeemResponse{
+		BlindSignatures: sigStrings,
+		BytesPerToken:   denom,
+		TokensRedeemed:  count,
+		TokensRemaining: remaining,
+	})
+}
+
+// handleSpend validates a token and checks for double-spend.
+//
+// Flow:
+//  1. Verify RSA blind signature on token
+//  2. Derive token_id (domain-separated SHA256)
+//  3. Atomically mark spent (INSERT ON CONFLICT DO NOTHING)
+//  4. Return {first_spend, bytes_per_token}
+//
+// POST /spend
+func (api *PurchaseAPI) handleSpend(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 4096) // token envelope is small
+
+	var req SpendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// --- Validate fields ---
+	if req.KeyID == "" {
+		jsonError(w, "key_id is required", http.StatusBadRequest)
+		return
+	}
+	if req.TokenSecret == "" {
+		jsonError(w, "token_secret is required", http.StatusBadRequest)
+		return
+	}
+	if req.Signature == "" {
+		jsonError(w, "signature is required", http.StatusBadRequest)
+		return
+	}
+	if req.NodePubkey == "" {
+		jsonError(w, "node_pubkey is required", http.StatusBadRequest)
+		return
+	}
+
+	// --- Decode hex fields ---
+	tokenSecret, err := hex.DecodeString(req.TokenSecret)
+	if err != nil {
+		jsonError(w, "token_secret must be valid hex", http.StatusBadRequest)
+		return
+	}
+	sig, err := hex.DecodeString(req.Signature)
+	if err != nil {
+		jsonError(w, "signature must be valid hex", http.StatusBadRequest)
+		return
+	}
+
+	// --- Reconstruct and verify token ---
+	token := &credentials.BlindToken{
+		Version:     credentials.BlindTokenVersion,
+		KeyID:       req.KeyID,
+		TokenSecret: tokenSecret,
+		Signature:   sig,
+	}
+
+	if err := api.blindVerifier.Verify(token); err != nil {
+		jsonError(w, "invalid token signature", http.StatusUnauthorized)
+		return
+	}
+
+	// --- Atomic double-spend check ---
+	tokenID := token.TokenID()
+	firstSpend, err := api.store.MarkSpent(tokenID, req.KeyID, req.NodePubkey)
+	if err != nil {
+		log.Printf("[blind-api] MarkSpent error for token %s: %v", tokenID, err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	denom, _ := api.blindVerifier.Denomination(req.KeyID)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(SpendResponse{
+		FirstSpend:    firstSpend,
+		BytesPerToken: denom,
+	})
+}
+
+// computeRequestHash creates a deterministic hash of the redemption request
+// for idempotency checking. Binds key_id + all blinded messages.
+func computeRequestHash(keyID string, blindedMessages []string) string {
+	h := sha256.New()
+	h.Write([]byte(keyID))
+	h.Write([]byte("|"))
+	h.Write([]byte(strings.Join(blindedMessages, "|")))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/payments/blind_api.go
+++ b/internal/payments/blind_api.go
@@ -47,10 +47,12 @@ type SpendResponse struct {
 }
 
 // EnableBlindSignatures registers the /redeem and /spend endpoints.
+// The defaultKeyID specifies which denomination key to use for new entitlements.
 // Call this after NewPurchaseAPI when Phase 4 blind signatures are enabled.
-func (api *PurchaseAPI) EnableBlindSignatures(mint credentials.BlindMint, verifier credentials.BlindVerifier) {
+func (api *PurchaseAPI) EnableBlindSignatures(mint credentials.BlindMint, verifier credentials.BlindVerifier, defaultKeyID string) {
 	api.blindMint = mint
 	api.blindVerifier = verifier
+	api.blindKeyID = defaultKeyID
 	api.mux.HandleFunc("/redeem", api.handleRedeem)
 	api.mux.HandleFunc("/spend", api.handleSpend)
 }

--- a/internal/payments/blind_api_test.go
+++ b/internal/payments/blind_api_test.go
@@ -37,7 +37,7 @@ func setupBlindTestEnv(t *testing.T) *blindTestEnv {
 		{KeyID: denomKey.KeyID, BytesPerToken: denomKey.BytesPerToken, PublicKey: denomKey.PublicKey},
 	})
 
-	env.api.EnableBlindSignatures(mint, verifier)
+	env.api.EnableBlindSignatures(mint, verifier, "key-100mb")
 
 	// Re-create server to pick up new routes.
 	env.server.Close()
@@ -620,5 +620,110 @@ func TestSpend_MethodNotAllowed(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Fatalf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+// --- Settlement creates entitlement ---
+
+func TestSettlement_CreatesEntitlement(t *testing.T) {
+	env := setupBlindTestEnv(t)
+
+	// Step 1: Purchase.
+	purchaseBody, _ := json.Marshal(PurchaseRequest{TierID: "1gb"})
+	resp := httpPost(t, env.server.URL+"/purchase", "application/json", bytes.NewReader(purchaseBody))
+	var purchase PurchaseResponse
+	json.NewDecoder(resp.Body).Decode(&purchase)
+	resp.Body.Close()
+
+	// Step 2: Settle the invoice via mock.
+	if err := env.mock.SimulateSettlement(purchase.PaymentHash); err != nil {
+		t.Fatalf("SimulateSettlement: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond) // let settlement listener process
+
+	// Step 3: Verify entitlement was created.
+	ent, err := env.store.GetEntitlementByPaymentHash(purchase.PaymentHash)
+	if err != nil {
+		t.Fatalf("GetEntitlementByPaymentHash: %v", err)
+	}
+
+	if ent.TokensTotal != 10 { // 1gb tier = 10 tickets
+		t.Errorf("expected 10 tokens total, got %d", ent.TokensTotal)
+	}
+	if ent.TokensRemaining != 10 {
+		t.Errorf("expected 10 tokens remaining, got %d", ent.TokensRemaining)
+	}
+	if ent.BytesPerToken != 100_000_000 {
+		t.Errorf("expected 100MB per token, got %d", ent.BytesPerToken)
+	}
+	if ent.KeyID != "key-100mb" {
+		t.Errorf("expected key-100mb, got %s", ent.KeyID)
+	}
+}
+
+// TestEndToEnd_PurchaseSettleRedeemSpend tests the complete Phase 4 flow:
+// purchase → pay → settle → redeem → spend
+func TestEndToEnd_PurchaseSettleRedeemSpend(t *testing.T) {
+	env := setupBlindTestEnv(t)
+
+	// Step 1: Purchase.
+	purchaseBody, _ := json.Marshal(PurchaseRequest{TierID: "1gb"})
+	resp := httpPost(t, env.server.URL+"/purchase", "application/json", bytes.NewReader(purchaseBody))
+	var purchase PurchaseResponse
+	json.NewDecoder(resp.Body).Decode(&purchase)
+	resp.Body.Close()
+
+	// Step 2: Settle invoice.
+	env.mock.SimulateSettlement(purchase.PaymentHash)
+	time.Sleep(200 * time.Millisecond)
+
+	// Step 3: Get the preimage from the mock.
+	preimage := env.mock.GetPreimage(purchase.PaymentHash)
+	if preimage == "" {
+		t.Fatal("no preimage from mock")
+	}
+
+	// Step 4: Redeem blind tokens.
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	redeemBody, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-e2e-full",
+	})
+	redeemResp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(redeemBody))
+	var redeemResult RedeemResponse
+	json.NewDecoder(redeemResp.Body).Decode(&redeemResult)
+	redeemResp.Body.Close()
+
+	if len(redeemResult.BlindSignatures) != 1 {
+		t.Fatalf("expected 1 signature, got %d", len(redeemResult.BlindSignatures))
+	}
+	if redeemResult.TokensRemaining != 9 {
+		t.Fatalf("expected 9 remaining, got %d", redeemResult.TokensRemaining)
+	}
+
+	// Step 5: Unblind and spend.
+	blindSig, _ := hex.DecodeString(redeemResult.BlindSignatures[0])
+	unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, bm.Unblinder)
+
+	spendBody, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-100mb",
+		TokenSecret: hex.EncodeToString(secret),
+		Signature:   hex.EncodeToString(unblinded),
+		NodePubkey:  "node-1",
+	})
+	spendResp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(spendBody))
+	var spendResult SpendResponse
+	json.NewDecoder(spendResp.Body).Decode(&spendResult)
+	spendResp.Body.Close()
+
+	if !spendResult.FirstSpend {
+		t.Error("expected first_spend=true")
+	}
+	if spendResult.BytesPerToken != 100_000_000 {
+		t.Error("expected 100MB denomination")
 	}
 }

--- a/internal/payments/blind_api_test.go
+++ b/internal/payments/blind_api_test.go
@@ -1,0 +1,624 @@
+package payments
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Radi-Labs/ARFL/internal/credentials"
+)
+
+// blindTestEnv extends testEnv with blind signature support.
+type blindTestEnv struct {
+	*testEnv
+	denomKey *credentials.DenominationKey
+	mint     *credentials.RSABlindMint
+	verifier *credentials.RSABlindVerifier
+}
+
+func setupBlindTestEnv(t *testing.T) *blindTestEnv {
+	t.Helper()
+
+	env := setupTestEnv(t)
+
+	// Generate a denomination key for testing.
+	denomKey, err := credentials.GenerateDenominationKey("key-100mb", 100_000_000)
+	if err != nil {
+		t.Fatalf("GenerateDenominationKey: %v", err)
+	}
+
+	mint := credentials.NewRSABlindMint([]*credentials.DenominationKey{denomKey})
+	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
+		{KeyID: denomKey.KeyID, BytesPerToken: denomKey.BytesPerToken, PublicKey: denomKey.PublicKey},
+	})
+
+	env.api.EnableBlindSignatures(mint, verifier)
+
+	// Re-create server to pick up new routes.
+	env.server.Close()
+	env.server = httptest.NewServer(env.api.Handler())
+	t.Cleanup(func() { env.server.Close() })
+
+	return &blindTestEnv{
+		testEnv:  env,
+		denomKey: denomKey,
+		mint:     mint,
+		verifier: verifier,
+	}
+}
+
+// createEntitlement inserts a settled invoice + entitlement for testing.
+// Returns the payment_hash and preimage.
+func (e *blindTestEnv) createEntitlement(t *testing.T, tokens int) (paymentHash, preimageHex string) {
+	t.Helper()
+
+	// Generate a fake preimage.
+	preimage := make([]byte, 32)
+	for i := range preimage {
+		preimage[i] = byte(i + 1)
+	}
+	preimageHex = hex.EncodeToString(preimage)
+
+	hashBytes := sha256.Sum256(preimage)
+	paymentHash = hex.EncodeToString(hashBytes[:])
+
+	// Insert a settled invoice.
+	err := e.store.InsertInvoice(paymentHash, "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC), "127.0.0.1")
+	if err != nil {
+		t.Fatalf("InsertInvoice: %v", err)
+	}
+	err = e.store.SettleInvoice(paymentHash)
+	if err != nil {
+		t.Fatalf("SettleInvoice: %v", err)
+	}
+
+	// Create entitlement.
+	err = e.store.InsertEntitlement("ent-"+paymentHash[:8], paymentHash, tokens, 100_000_000, "key-100mb")
+	if err != nil {
+		t.Fatalf("InsertEntitlement: %v", err)
+	}
+
+	return paymentHash, preimageHex
+}
+
+// --- /redeem tests ---
+
+func TestRedeem_FullFlow(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	// Generate blinded messages.
+	secret, err := credentials.GenerateTokenSecret()
+	if err != nil {
+		t.Fatalf("GenerateTokenSecret: %v", err)
+	}
+	bm, err := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+	if err != nil {
+		t.Fatalf("BlindTokenSecret: %v", err)
+	}
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-1",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp map[string]string
+		json.NewDecoder(resp.Body).Decode(&errResp)
+		t.Fatalf("expected 200, got %d: %v", resp.StatusCode, errResp)
+	}
+
+	var result RedeemResponse
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	if len(result.BlindSignatures) != 1 {
+		t.Fatalf("expected 1 signature, got %d", len(result.BlindSignatures))
+	}
+	if result.BytesPerToken != 100_000_000 {
+		t.Errorf("expected 100MB denomination, got %d", result.BytesPerToken)
+	}
+	if result.TokensRedeemed != 1 {
+		t.Errorf("expected 1 redeemed, got %d", result.TokensRedeemed)
+	}
+	if result.TokensRemaining != 9 {
+		t.Errorf("expected 9 remaining, got %d", result.TokensRemaining)
+	}
+
+	// Unblind and verify the signature.
+	blindSig, _ := hex.DecodeString(result.BlindSignatures[0])
+	unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, bm.Unblinder)
+	token := &credentials.BlindToken{
+		Version:     credentials.BlindTokenVersion,
+		KeyID:       "key-100mb",
+		TokenSecret: secret,
+		Signature:   unblinded,
+	}
+	if err := env.verifier.Verify(token); err != nil {
+		t.Errorf("unblinded signature failed verification: %v", err)
+	}
+}
+
+func TestRedeem_BatchMessages(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 5)
+
+	// Generate 3 blinded messages.
+	msgs := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		secret, _ := credentials.GenerateTokenSecret()
+		bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+		msgs[i] = hex.EncodeToString(bm.Blinded)
+	}
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: msgs,
+		Nonce:           "nonce-batch",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result RedeemResponse
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	if len(result.BlindSignatures) != 3 {
+		t.Fatalf("expected 3 signatures, got %d", len(result.BlindSignatures))
+	}
+	if result.TokensRedeemed != 3 {
+		t.Errorf("expected 3 redeemed, got %d", result.TokensRedeemed)
+	}
+	if result.TokensRemaining != 2 {
+		t.Errorf("expected 2 remaining, got %d", result.TokensRemaining)
+	}
+}
+
+func TestRedeem_IdempotentReplay(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-idempotent",
+	})
+
+	// First request.
+	resp1 := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", resp1.StatusCode)
+	}
+	var result1 RedeemResponse
+	json.NewDecoder(resp1.Body).Decode(&result1)
+
+	// Second request with same nonce + same request.
+	resp2 := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("replay: expected 200, got %d", resp2.StatusCode)
+	}
+	var result2 RedeemResponse
+	json.NewDecoder(resp2.Body).Decode(&result2)
+
+	// Same signatures returned.
+	if len(result2.BlindSignatures) != len(result1.BlindSignatures) {
+		t.Fatalf("replay returned different sig count")
+	}
+	if result2.BlindSignatures[0] != result1.BlindSignatures[0] {
+		t.Error("replay returned different signature")
+	}
+
+	// Tokens should NOT be consumed again.
+	if result2.TokensRemaining != 9 {
+		t.Errorf("expected 9 remaining after replay, got %d", result2.TokensRemaining)
+	}
+}
+
+func TestRedeem_NonceConflict(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	secret1, _ := credentials.GenerateTokenSecret()
+	bm1, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret1)
+
+	secret2, _ := credentials.GenerateTokenSecret()
+	bm2, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret2)
+
+	// First request.
+	body1, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm1.Blinded)},
+		Nonce:           "nonce-conflict",
+	})
+	resp1 := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body1))
+	resp1.Body.Close()
+
+	// Second request with same nonce but different blinded messages.
+	body2, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm2.Blinded)},
+		Nonce:           "nonce-conflict",
+	})
+	resp2 := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body2))
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict, got %d", resp2.StatusCode)
+	}
+}
+
+func TestRedeem_InsufficientTokens(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 2)
+
+	// Try to redeem 3 tokens when only 2 exist.
+	msgs := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		secret, _ := credentials.GenerateTokenSecret()
+		bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+		msgs[i] = hex.EncodeToString(bm.Blinded)
+	}
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: msgs,
+		Nonce:           "nonce-overdraw",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", resp.StatusCode)
+	}
+}
+
+func TestRedeem_InvalidPreimage(t *testing.T) {
+	env := setupBlindTestEnv(t)
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: "not-valid-hex",
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{"aabbccdd"},
+		Nonce:           "nonce-1",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestRedeem_NoEntitlement(t *testing.T) {
+	env := setupBlindTestEnv(t)
+
+	// Valid preimage but no matching entitlement.
+	preimage := make([]byte, 32)
+	preimage[0] = 0xFF
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: hex.EncodeToString(preimage),
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-noent",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestRedeem_WrongKeyID(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "wrong-key-id",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-wrong-key",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// --- /spend tests ---
+
+func TestSpend_FullFlow(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	// Step 1: Redeem to get a blind signature.
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	redeemBody, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-spend",
+	})
+
+	redeemResp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(redeemBody))
+	var redeemResult RedeemResponse
+	json.NewDecoder(redeemResp.Body).Decode(&redeemResult)
+	redeemResp.Body.Close()
+
+	// Unblind the signature.
+	blindSig, _ := hex.DecodeString(redeemResult.BlindSignatures[0])
+	unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, bm.Unblinder)
+
+	// Step 2: Spend the token.
+	spendBody, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-100mb",
+		TokenSecret: hex.EncodeToString(secret),
+		Signature:   hex.EncodeToString(unblinded),
+		NodePubkey:  "node-pubkey-1",
+	})
+
+	resp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(spendBody))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp map[string]string
+		json.NewDecoder(resp.Body).Decode(&errResp)
+		t.Fatalf("expected 200, got %d: %v", resp.StatusCode, errResp)
+	}
+
+	var result SpendResponse
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	if !result.FirstSpend {
+		t.Error("expected first_spend=true")
+	}
+	if result.BytesPerToken != 100_000_000 {
+		t.Errorf("expected 100MB denomination, got %d", result.BytesPerToken)
+	}
+}
+
+func TestSpend_DoubleSpend(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	// Redeem.
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	redeemBody, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-double",
+	})
+	redeemResp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(redeemBody))
+	var redeemResult RedeemResponse
+	json.NewDecoder(redeemResp.Body).Decode(&redeemResult)
+	redeemResp.Body.Close()
+
+	blindSig, _ := hex.DecodeString(redeemResult.BlindSignatures[0])
+	unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, bm.Unblinder)
+
+	spendBody, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-100mb",
+		TokenSecret: hex.EncodeToString(secret),
+		Signature:   hex.EncodeToString(unblinded),
+		NodePubkey:  "node-pubkey-1",
+	})
+
+	// First spend.
+	resp1 := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(spendBody))
+	var result1 SpendResponse
+	json.NewDecoder(resp1.Body).Decode(&result1)
+	resp1.Body.Close()
+
+	if !result1.FirstSpend {
+		t.Fatal("first spend should be true")
+	}
+
+	// Second spend — same token.
+	resp2 := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(spendBody))
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("double-spend should still return 200 with first_spend=false, got %d", resp2.StatusCode)
+	}
+
+	var result2 SpendResponse
+	json.NewDecoder(resp2.Body).Decode(&result2)
+
+	if result2.FirstSpend {
+		t.Error("second spend should have first_spend=false")
+	}
+}
+
+func TestSpend_InvalidSignature(t *testing.T) {
+	env := setupBlindTestEnv(t)
+
+	secret, _ := credentials.GenerateTokenSecret()
+
+	body, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-100mb",
+		TokenSecret: hex.EncodeToString(secret),
+		Signature:   hex.EncodeToString(make([]byte, 256)), // garbage signature
+		NodePubkey:  "node-pubkey-1",
+	})
+
+	resp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestSpend_MissingFields(t *testing.T) {
+	env := setupBlindTestEnv(t)
+
+	cases := []struct {
+		name string
+		req  SpendRequest
+	}{
+		{"missing key_id", SpendRequest{TokenSecret: "aabb", Signature: "ccdd", NodePubkey: "node"}},
+		{"missing token_secret", SpendRequest{KeyID: "key-100mb", Signature: "ccdd", NodePubkey: "node"}},
+		{"missing signature", SpendRequest{KeyID: "key-100mb", TokenSecret: "aabb", NodePubkey: "node"}},
+		{"missing node_pubkey", SpendRequest{KeyID: "key-100mb", TokenSecret: "aabb", Signature: "ccdd"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(tc.req)
+			resp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(body))
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestRedeem_MissingFields(t *testing.T) {
+	env := setupBlindTestEnv(t)
+
+	cases := []struct {
+		name string
+		req  RedeemRequest
+		code int
+	}{
+		{"missing preimage", RedeemRequest{KeyID: "k", BlindedMessages: []string{"aa"}, Nonce: "n"}, http.StatusBadRequest},
+		{"missing key_id", RedeemRequest{PaymentPreimage: hex.EncodeToString(make([]byte, 32)), BlindedMessages: []string{"aa"}, Nonce: "n"}, http.StatusBadRequest},
+		{"missing messages", RedeemRequest{PaymentPreimage: hex.EncodeToString(make([]byte, 32)), KeyID: "k", Nonce: "n"}, http.StatusBadRequest},
+		{"missing nonce", RedeemRequest{PaymentPreimage: hex.EncodeToString(make([]byte, 32)), KeyID: "k", BlindedMessages: []string{"aa"}}, http.StatusBadRequest},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(tc.req)
+			resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+			defer resp.Body.Close()
+			if resp.StatusCode != tc.code {
+				t.Fatalf("expected %d, got %d", tc.code, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// --- End-to-end: Redeem → Spend ---
+
+func TestEndToEnd_RedeemAndSpend(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 5)
+
+	// Redeem 3 tokens.
+	secrets := make([][]byte, 3)
+	blindedMsgs := make([]string, 3)
+	unblinders := make([][]byte, 3)
+
+	for i := 0; i < 3; i++ {
+		s, _ := credentials.GenerateTokenSecret()
+		bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, s)
+		secrets[i] = s
+		blindedMsgs[i] = hex.EncodeToString(bm.Blinded)
+		unblinders[i] = bm.Unblinder
+	}
+
+	redeemBody, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: blindedMsgs,
+		Nonce:           "nonce-e2e",
+	})
+	redeemResp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(redeemBody))
+	var redeemResult RedeemResponse
+	json.NewDecoder(redeemResp.Body).Decode(&redeemResult)
+	redeemResp.Body.Close()
+
+	if redeemResult.TokensRedeemed != 3 {
+		t.Fatalf("expected 3 redeemed, got %d", redeemResult.TokensRedeemed)
+	}
+	if redeemResult.TokensRemaining != 2 {
+		t.Fatalf("expected 2 remaining, got %d", redeemResult.TokensRemaining)
+	}
+
+	// Spend each token.
+	for i := 0; i < 3; i++ {
+		blindSig, _ := hex.DecodeString(redeemResult.BlindSignatures[i])
+		unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, unblinders[i])
+
+		spendBody, _ := json.Marshal(SpendRequest{
+			KeyID:       "key-100mb",
+			TokenSecret: hex.EncodeToString(secrets[i]),
+			Signature:   hex.EncodeToString(unblinded),
+			NodePubkey:  "node-pubkey-1",
+		})
+
+		resp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(spendBody))
+		var result SpendResponse
+		json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+
+		if !result.FirstSpend {
+			t.Errorf("token %d: expected first_spend=true", i)
+		}
+		if result.BytesPerToken != 100_000_000 {
+			t.Errorf("token %d: expected 100MB, got %d", i, result.BytesPerToken)
+		}
+	}
+}
+
+func TestRedeem_MethodNotAllowed(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	resp := httpGet(t, env.server.URL+"/redeem")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestSpend_MethodNotAllowed(t *testing.T) {
+	env := setupBlindTestEnv(t)
+	resp := httpGet(t, env.server.URL+"/spend")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", resp.StatusCode)
+	}
+}

--- a/internal/payments/blind_stride_test.go
+++ b/internal/payments/blind_stride_test.go
@@ -1,0 +1,557 @@
+package payments
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Radi-Labs/ARFL/internal/credentials"
+)
+
+// STRIDE tests for the blind signature endpoints.
+// These test adversarial scenarios beyond happy-path functionality.
+
+// --- Spoofing ---
+
+func TestSTRIDE_Redeem_SpoofedPreimage(t *testing.T) {
+	// An attacker who doesn't know the real preimage cannot redeem.
+	env := setupBlindTestEnv(t)
+	_, _ = env.createEntitlement(t, 10) // real entitlement exists
+
+	// Attacker uses a random preimage that doesn't match any payment.
+	fakePreimage := make([]byte, 32)
+	fakePreimage[0] = 0xDE
+	fakePreimage[1] = 0xAD
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: hex.EncodeToString(fakePreimage),
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-spoof",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("spoofed preimage should be rejected: expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestSTRIDE_Spend_ForgedSignature(t *testing.T) {
+	// An attacker tries to spend a token with a forged signature.
+	env := setupBlindTestEnv(t)
+
+	secret, _ := credentials.GenerateTokenSecret()
+	fakeSig := make([]byte, 256) // RSA signature size but all zeros
+	for i := range fakeSig {
+		fakeSig[i] = byte(i % 256)
+	}
+
+	body, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-100mb",
+		TokenSecret: hex.EncodeToString(secret),
+		Signature:   hex.EncodeToString(fakeSig),
+		NodePubkey:  "attacker-node",
+	})
+
+	resp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("forged signature should be rejected: expected 401, got %d", resp.StatusCode)
+	}
+}
+
+// --- Tampering ---
+
+func TestSTRIDE_Spend_TamperedTokenSecret(t *testing.T) {
+	// Attacker gets a valid signature but tampers with the token secret.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	// Redeem legitimately.
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	redeemBody, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-tamper",
+	})
+	redeemResp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(redeemBody))
+	var redeemResult RedeemResponse
+	json.NewDecoder(redeemResp.Body).Decode(&redeemResult)
+	redeemResp.Body.Close()
+
+	blindSig, _ := hex.DecodeString(redeemResult.BlindSignatures[0])
+	unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, bm.Unblinder)
+
+	// Tamper: flip a bit in the token secret.
+	tamperedSecret := make([]byte, len(secret))
+	copy(tamperedSecret, secret)
+	tamperedSecret[0] ^= 0xFF
+
+	body, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-100mb",
+		TokenSecret: hex.EncodeToString(tamperedSecret),
+		Signature:   hex.EncodeToString(unblinded),
+		NodePubkey:  "node-1",
+	})
+
+	resp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("tampered token should be rejected: expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestSTRIDE_Redeem_BodyTooLarge(t *testing.T) {
+	// Attacker sends an oversized body to exhaust memory.
+	env := setupBlindTestEnv(t)
+
+	// 300KB of garbage (exceeds 256KB limit).
+	largeBody := strings.Repeat("A", 300*1024)
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader([]byte(largeBody)))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("oversized body should be rejected: expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// --- Repudiation ---
+
+func TestSTRIDE_Redeem_CachedRedemptionPersists(t *testing.T) {
+	// After a successful redemption, the nonce + request_hash are cached.
+	// This ensures the Hub can prove the redemption happened.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 5)
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-audit-trail",
+	})
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	resp.Body.Close()
+
+	// Verify redemption exists in DB.
+	rec, err := env.store.GetRedemption("nonce-audit-trail")
+	if err != nil {
+		t.Fatalf("GetRedemption: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("redemption not cached — no audit trail")
+	}
+	if rec.TokensCount != 1 {
+		t.Errorf("expected 1 token, got %d", rec.TokensCount)
+	}
+}
+
+func TestSTRIDE_Spend_SpentTokenRecorded(t *testing.T) {
+	// After spending, the token is recorded in spent_tokens for audit.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	redeemBody, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-audit-spend",
+	})
+	redeemResp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(redeemBody))
+	var redeemResult RedeemResponse
+	json.NewDecoder(redeemResp.Body).Decode(&redeemResult)
+	redeemResp.Body.Close()
+
+	blindSig, _ := hex.DecodeString(redeemResult.BlindSignatures[0])
+	unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, bm.Unblinder)
+
+	spendBody, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-100mb",
+		TokenSecret: hex.EncodeToString(secret),
+		Signature:   hex.EncodeToString(unblinded),
+		NodePubkey:  "node-audit",
+	})
+	resp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(spendBody))
+	resp.Body.Close()
+
+	// Verify spent token is in DB.
+	token := &credentials.BlindToken{
+		Version:     credentials.BlindTokenVersion,
+		KeyID:       "key-100mb",
+		TokenSecret: secret,
+	}
+	spent, err := env.store.IsSpent(token.TokenID())
+	if err != nil {
+		t.Fatalf("IsSpent: %v", err)
+	}
+	if !spent {
+		t.Fatal("token not recorded as spent — no audit trail")
+	}
+}
+
+// --- Denial of Service ---
+
+func TestSTRIDE_Redeem_TooManyMessages(t *testing.T) {
+	// Attacker tries to redeem more messages than MaxBlindMessagesPerRequest.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 1000)
+
+	msgs := make([]string, credentials.MaxBlindMessagesPerRequest+1)
+	for i := range msgs {
+		msgs[i] = hex.EncodeToString(make([]byte, 32))
+	}
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: msgs,
+		Nonce:           "nonce-dos",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("too many messages should be rejected: expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// --- Elevation of Privilege ---
+
+func TestSTRIDE_Redeem_CrossKeyRedemption(t *testing.T) {
+	// Attacker tries to redeem with a different key_id than the entitlement's.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10) // entitlement is for key-100mb
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-1gb", // wrong key
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-cross-key",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("cross-key redemption should be rejected: expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestSTRIDE_Redeem_ConsumeMoreThanEntitled(t *testing.T) {
+	// Attacker redeems all tokens, then tries to redeem more.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 2) // only 2 tokens
+
+	// First redemption: use all 2 tokens.
+	msgs := make([]string, 2)
+	for i := 0; i < 2; i++ {
+		s, _ := credentials.GenerateTokenSecret()
+		bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, s)
+		msgs[i] = hex.EncodeToString(bm.Blinded)
+	}
+
+	body1, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: msgs,
+		Nonce:           "nonce-exhaust",
+	})
+	resp1 := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body1))
+	resp1.Body.Close()
+
+	// Second redemption: try to get 1 more.
+	s, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, s)
+
+	body2, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-overreach",
+	})
+	resp2 := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body2))
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("over-entitlement should be rejected: expected 402, got %d", resp2.StatusCode)
+	}
+}
+
+func TestSTRIDE_Spend_CrossKeyReplay(t *testing.T) {
+	// Attacker redeems with key-100mb, tries to spend pretending it's a
+	// different key. The signature won't verify against the wrong key.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	redeemBody, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-cross-spend",
+	})
+	redeemResp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(redeemBody))
+	var redeemResult RedeemResponse
+	json.NewDecoder(redeemResp.Body).Decode(&redeemResult)
+	redeemResp.Body.Close()
+
+	blindSig, _ := hex.DecodeString(redeemResult.BlindSignatures[0])
+	unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, bm.Unblinder)
+
+	// Try to spend with a different key_id.
+	body, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-1gb", // wrong key
+		TokenSecret: hex.EncodeToString(secret),
+		Signature:   hex.EncodeToString(unblinded),
+		NodePubkey:  "node-1",
+	})
+
+	resp := httpPost(t, env.server.URL+"/spend", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	// Should fail because key-1gb doesn't exist in the verifier.
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("cross-key spend should fail: got %d", resp.StatusCode)
+	}
+}
+
+// --- Concurrent STRIDE ---
+
+func TestSTRIDE_ConcurrentRedeem_NoOverdraw(t *testing.T) {
+	// Multiple concurrent redemptions must not overdraw the entitlement.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 5) // 5 tokens total
+
+	var wg sync.WaitGroup
+	var successCount int32
+	var failCount int32
+
+	// Launch 10 concurrent requests, each asking for 1 token.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			s, _ := credentials.GenerateTokenSecret()
+			bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, s)
+
+			body, _ := json.Marshal(RedeemRequest{
+				PaymentPreimage: preimage,
+				KeyID:           "key-100mb",
+				BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+				Nonce:           fmt.Sprintf("nonce-concurrent-%d", idx),
+			})
+
+			resp, err := http.Post(env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+			if err != nil {
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode == http.StatusOK {
+				atomic.AddInt32(&successCount, 1)
+			} else {
+				atomic.AddInt32(&failCount, 1)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	if successCount > 5 {
+		t.Fatalf("overdraw: %d successful redemptions from 5-token entitlement", successCount)
+	}
+	if successCount < 1 {
+		t.Fatal("no successful redemptions — test setup error")
+	}
+}
+
+func TestSTRIDE_ConcurrentSpend_ExactlyOneFirstSpend(t *testing.T) {
+	// Multiple concurrent spends of the same token: exactly one is first_spend=true.
+	env := setupBlindTestEnv(t)
+	_, preimage := env.createEntitlement(t, 10)
+
+	// Redeem a token.
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	redeemBody, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: preimage,
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-race-spend",
+	})
+	redeemResp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(redeemBody))
+	var redeemResult RedeemResponse
+	json.NewDecoder(redeemResp.Body).Decode(&redeemResult)
+	redeemResp.Body.Close()
+
+	blindSig, _ := hex.DecodeString(redeemResult.BlindSignatures[0])
+	unblinded := credentials.UnblindSignature(env.denomKey.PublicKey, blindSig, bm.Unblinder)
+
+	spendBody, _ := json.Marshal(SpendRequest{
+		KeyID:       "key-100mb",
+		TokenSecret: hex.EncodeToString(secret),
+		Signature:   hex.EncodeToString(unblinded),
+		NodePubkey:  "node-race",
+	})
+
+	var wg sync.WaitGroup
+	var firstSpendCount int32
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			resp, err := http.Post(env.server.URL+"/spend", "application/json", bytes.NewReader(spendBody))
+			if err != nil {
+				return
+			}
+			defer resp.Body.Close()
+
+			var result SpendResponse
+			json.NewDecoder(resp.Body).Decode(&result)
+			if result.FirstSpend {
+				atomic.AddInt32(&firstSpendCount, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if firstSpendCount != 1 {
+		t.Fatalf("expected exactly 1 first_spend, got %d", firstSpendCount)
+	}
+}
+
+// --- Information Disclosure ---
+
+func TestSTRIDE_Redeem_PreimageNotLeakedInErrors(t *testing.T) {
+	// Error responses must not leak the payment hash derived from the preimage.
+	env := setupBlindTestEnv(t)
+
+	preimage := make([]byte, 32)
+	preimage[0] = 0xBE
+	preimage[1] = 0xEF
+	hash := sha256.Sum256(preimage)
+	paymentHash := hex.EncodeToString(hash[:])
+
+	secret, _ := credentials.GenerateTokenSecret()
+	bm, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, secret)
+
+	body, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: hex.EncodeToString(preimage),
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm.Blinded)},
+		Nonce:           "nonce-leak-test",
+	})
+
+	resp := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body))
+	defer resp.Body.Close()
+
+	var errResp map[string]string
+	json.NewDecoder(resp.Body).Decode(&errResp)
+
+	// The error message should NOT contain the payment hash.
+	if msg, ok := errResp["error"]; ok {
+		if strings.Contains(msg, paymentHash) {
+			t.Errorf("error response leaks payment_hash: %s", msg)
+		}
+		if strings.Contains(msg, hex.EncodeToString(preimage)) {
+			t.Errorf("error response leaks preimage: %s", msg)
+		}
+	}
+}
+
+// --- Replay Resistance ---
+
+func TestSTRIDE_Redeem_OldPreimageNewEntitlement(t *testing.T) {
+	// After exhausting entitlement, buying a new one with a different preimage
+	// should not allow reuse of old nonces.
+	env := setupBlindTestEnv(t)
+
+	// First entitlement: 1 token.
+	preimage1 := make([]byte, 32)
+	for i := range preimage1 {
+		preimage1[i] = byte(i + 10)
+	}
+	hash1 := sha256.Sum256(preimage1)
+	paymentHash1 := hex.EncodeToString(hash1[:])
+
+	env.store.InsertInvoice(paymentHash1, "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC), "127.0.0.1")
+	env.store.SettleInvoice(paymentHash1)
+	env.store.InsertEntitlement("ent-1", paymentHash1, 1, 100_000_000, "key-100mb")
+
+	// Redeem from first entitlement.
+	s1, _ := credentials.GenerateTokenSecret()
+	bm1, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, s1)
+	body1, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: hex.EncodeToString(preimage1),
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm1.Blinded)},
+		Nonce:           "shared-nonce",
+	})
+	resp1 := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body1))
+	resp1.Body.Close()
+
+	// Second entitlement: 1 token, different preimage.
+	preimage2 := make([]byte, 32)
+	for i := range preimage2 {
+		preimage2[i] = byte(i + 20)
+	}
+	hash2 := sha256.Sum256(preimage2)
+	paymentHash2 := hex.EncodeToString(hash2[:])
+
+	env.store.InsertInvoice(paymentHash2, "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC), "127.0.0.2")
+	env.store.SettleInvoice(paymentHash2)
+	env.store.InsertEntitlement("ent-2", paymentHash2, 1, 100_000_000, "key-100mb")
+
+	// Try to use the same nonce with the second entitlement.
+	s2, _ := credentials.GenerateTokenSecret()
+	bm2, _ := credentials.BlindTokenSecret(env.denomKey.PublicKey, s2)
+	body2, _ := json.Marshal(RedeemRequest{
+		PaymentPreimage: hex.EncodeToString(preimage2),
+		KeyID:           "key-100mb",
+		BlindedMessages: []string{hex.EncodeToString(bm2.Blinded)},
+		Nonce:           "shared-nonce", // same nonce, different payment
+	})
+	resp2 := httpPost(t, env.server.URL+"/redeem", "application/json", bytes.NewReader(body2))
+	defer resp2.Body.Close()
+
+	// Should conflict because nonce is already used (even for different payment).
+	if resp2.StatusCode != http.StatusConflict {
+		t.Fatalf("reused nonce should conflict: expected 409, got %d", resp2.StatusCode)
+	}
+}

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -609,3 +609,129 @@ func (s *Store) GetTicketSettlementInfo(ticketID string) (*TicketSettlementInfo,
 	}
 	return &info, nil
 }
+
+// --- Entitlement operations (Phase 4: blind signatures) ---
+
+// EntitlementRecord is the read model for an entitlement.
+type EntitlementRecord struct {
+	ID              string
+	PaymentHash     string
+	TokensRemaining int
+	TokensTotal     int
+	BytesPerToken   int64
+	KeyID           string
+	CreatedAt       string
+}
+
+// InsertEntitlement creates a new entitlement for a settled invoice.
+// Called by the settlement listener when an invoice is paid.
+func (s *Store) InsertEntitlement(id, paymentHash string, tokensTotal int, bytesPerToken int64, keyID string) error {
+	_, err := s.db.Exec(`
+INSERT INTO entitlements (id, payment_hash, tokens_remaining, tokens_total, bytes_per_token, key_id)
+VALUES (?, ?, ?, ?, ?, ?)`,
+		id, paymentHash, tokensTotal, tokensTotal, bytesPerToken, keyID,
+	)
+	return err
+}
+
+// GetEntitlementByPaymentHash retrieves the entitlement for a given invoice.
+func (s *Store) GetEntitlementByPaymentHash(paymentHash string) (*EntitlementRecord, error) {
+	row := s.db.QueryRow(`
+SELECT id, payment_hash, tokens_remaining, tokens_total, bytes_per_token, key_id, created_at
+FROM entitlements WHERE payment_hash = ?`, paymentHash)
+
+	var e EntitlementRecord
+	err := row.Scan(&e.ID, &e.PaymentHash, &e.TokensRemaining, &e.TokensTotal,
+		&e.BytesPerToken, &e.KeyID, &e.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+// ConsumeEntitlement atomically decrements tokens_remaining by count.
+// Returns an error if insufficient tokens remain (0 rows affected).
+// This is the sole entitlement mutation operation — all other fields are immutable.
+func (s *Store) ConsumeEntitlement(entitlementID string, count int) error {
+	res, err := s.db.Exec(`
+UPDATE entitlements
+SET tokens_remaining = tokens_remaining - ?
+WHERE id = ? AND tokens_remaining >= ?`,
+		count, entitlementID, count,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("insufficient entitlement: %s (requested %d)", entitlementID, count)
+	}
+	return nil
+}
+
+// --- Spent token operations (Phase 4: double-spend prevention) ---
+
+// MarkSpent atomically checks and marks a token as spent.
+// Returns (true, nil) if this is the first spend (insert succeeded).
+// Returns (false, nil) if the token was already spent (conflict).
+// This is the SOLE double-spend prevention primitive — never do separate check + insert.
+func (s *Store) MarkSpent(tokenID, keyID, nodePubkey string) (bool, error) {
+	res, err := s.db.Exec(`
+INSERT INTO spent_tokens (token_id, key_id, node_pubkey)
+VALUES (?, ?, ?)
+ON CONFLICT(token_id) DO NOTHING`,
+		tokenID, keyID, nodePubkey,
+	)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
+}
+
+// IsSpent checks whether a token has been spent (read-only).
+func (s *Store) IsSpent(tokenID string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM spent_tokens WHERE token_id = ?`, tokenID).Scan(&count)
+	return count > 0, err
+}
+
+// --- Redemption cache operations (Phase 4: idempotent /redeem) ---
+
+// InsertRedemption stores a completed redemption for crash recovery.
+// The nonce + request_hash pair ensures idempotent retries.
+func (s *Store) InsertRedemption(nonce, entitlementID, requestHash string, tokensCount int, blindSignaturesJSON string) error {
+	_, err := s.db.Exec(`
+INSERT INTO redemptions (nonce, entitlement_id, request_hash, tokens_count, blind_signatures)
+VALUES (?, ?, ?, ?, ?)`,
+		nonce, entitlementID, requestHash, tokensCount, blindSignaturesJSON,
+	)
+	return err
+}
+
+// RedemptionRecord is the read model for a cached redemption.
+type RedemptionRecord struct {
+	Nonce           string
+	EntitlementID   string
+	RequestHash     string
+	TokensCount     int
+	BlindSignatures string // JSON array of base64 signatures
+}
+
+// GetRedemption retrieves a cached redemption by nonce.
+// Returns (nil, nil) if not found.
+func (s *Store) GetRedemption(nonce string) (*RedemptionRecord, error) {
+	row := s.db.QueryRow(`
+SELECT nonce, entitlement_id, request_hash, tokens_count, blind_signatures
+FROM redemptions WHERE nonce = ?`, nonce)
+
+	var r RedemptionRecord
+	err := row.Scan(&r.Nonce, &r.EntitlementID, &r.RequestHash, &r.TokensCount, &r.BlindSignatures)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -242,4 +242,89 @@ BEFORE DELETE ON compensating_entries
 BEGIN
     SELECT RAISE(FAIL, 'compensating_entries is append-only: deletions are prohibited');
 END;
+
+-- ============================================================
+-- ENTITLEMENTS: Track redeemable token quotas per purchase
+-- Created when an invoice is settled. Decremented when client
+-- redeems tokens via POST /redeem.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS entitlements (
+    id               TEXT    PRIMARY KEY,
+    payment_hash     TEXT    NOT NULL UNIQUE REFERENCES invoices(payment_hash),
+    tokens_remaining INTEGER NOT NULL CHECK (tokens_remaining >= 0),
+    tokens_total     INTEGER NOT NULL CHECK (tokens_total > 0),
+    bytes_per_token  INTEGER NOT NULL CHECK (bytes_per_token > 0),
+    key_id           TEXT    NOT NULL,
+    created_at       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_entitlements_payment ON entitlements(payment_hash);
+
+-- Entitlements: no deletion.
+CREATE TRIGGER IF NOT EXISTS entitlements_no_delete
+BEFORE DELETE ON entitlements
+BEGIN
+    SELECT RAISE(FAIL, 'entitlements is append-only: deletions are prohibited');
+END;
+
+-- Entitlements: immutable fields (only tokens_remaining may change).
+CREATE TRIGGER IF NOT EXISTS entitlements_immutable_fields
+BEFORE UPDATE ON entitlements
+WHEN OLD.payment_hash != NEW.payment_hash
+  OR OLD.tokens_total != NEW.tokens_total
+  OR OLD.bytes_per_token != NEW.bytes_per_token
+  OR OLD.key_id != NEW.key_id
+BEGIN
+    SELECT RAISE(FAIL, 'entitlement financial fields are immutable');
+END;
+
+-- ============================================================
+-- SPENT TOKENS: Double-spend prevention for blind-signed tokens
+-- Atomic INSERT is the sole correctness primitive.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS spent_tokens (
+    token_id    TEXT PRIMARY KEY,
+    key_id      TEXT NOT NULL,
+    node_pubkey TEXT NOT NULL,
+    spent_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- Spent tokens are never deleted or modified.
+CREATE TRIGGER IF NOT EXISTS spent_tokens_no_delete
+BEFORE DELETE ON spent_tokens
+BEGIN
+    SELECT RAISE(FAIL, 'spent_tokens is append-only: deletions are prohibited');
+END;
+
+CREATE TRIGGER IF NOT EXISTS spent_tokens_no_update
+BEFORE UPDATE ON spent_tokens
+BEGIN
+    SELECT RAISE(FAIL, 'spent_tokens is append-only: updates are prohibited');
+END;
+
+-- ============================================================
+-- REDEMPTIONS: Idempotent /redeem response cache
+-- Ensures crash-safe blind signature delivery.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS redemptions (
+    nonce           TEXT PRIMARY KEY,
+    entitlement_id  TEXT    NOT NULL REFERENCES entitlements(id),
+    request_hash    TEXT    NOT NULL,
+    tokens_count    INTEGER NOT NULL CHECK (tokens_count > 0),
+    blind_signatures TEXT   NOT NULL,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- Redemptions are never deleted or modified.
+CREATE TRIGGER IF NOT EXISTS redemptions_no_delete
+BEFORE DELETE ON redemptions
+BEGIN
+    SELECT RAISE(FAIL, 'redemptions is append-only: deletions are prohibited');
+END;
+
+CREATE TRIGGER IF NOT EXISTS redemptions_no_update
+BEFORE UPDATE ON redemptions
+BEGIN
+    SELECT RAISE(FAIL, 'redemptions is append-only: updates are prohibited');
+END;
 `

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -681,5 +682,308 @@ func TestSTRIDE_PayoutSettlementRefImmutable(t *testing.T) {
 	_, err := s.db.Exec(`UPDATE payouts SET settlement_entry_id = ? WHERE id = ?`, entryID2, payoutID)
 	if err == nil {
 		t.Fatal("should not allow changing payout settlement_entry_id")
+	}
+}
+
+// ============================================================
+// Phase 4: Entitlement tests
+// ============================================================
+
+func TestEntitlement_InsertAndGet(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-e1", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-e1")
+
+	err := s.InsertEntitlement("ent-1", "hash-e1", 10, 100_000_000, "key-100mb")
+	if err != nil {
+		t.Fatalf("InsertEntitlement: %v", err)
+	}
+
+	e, err := s.GetEntitlementByPaymentHash("hash-e1")
+	if err != nil {
+		t.Fatalf("GetEntitlement: %v", err)
+	}
+	if e.TokensRemaining != 10 || e.TokensTotal != 10 {
+		t.Errorf("tokens: remaining=%d, total=%d", e.TokensRemaining, e.TokensTotal)
+	}
+	if e.BytesPerToken != 100_000_000 {
+		t.Errorf("bytes_per_token = %d", e.BytesPerToken)
+	}
+	if e.KeyID != "key-100mb" {
+		t.Errorf("key_id = %s", e.KeyID)
+	}
+}
+
+func TestEntitlement_ConsumeDecrementsRemaining(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-c1", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-c1")
+	s.InsertEntitlement("ent-c1", "hash-c1", 10, 100_000_000, "key-1")
+
+	// Consume 3 tokens.
+	if err := s.ConsumeEntitlement("ent-c1", 3); err != nil {
+		t.Fatalf("ConsumeEntitlement(3): %v", err)
+	}
+
+	e, _ := s.GetEntitlementByPaymentHash("hash-c1")
+	if e.TokensRemaining != 7 {
+		t.Errorf("remaining = %d, want 7", e.TokensRemaining)
+	}
+
+	// Consume remaining 7.
+	if err := s.ConsumeEntitlement("ent-c1", 7); err != nil {
+		t.Fatalf("ConsumeEntitlement(7): %v", err)
+	}
+
+	e, _ = s.GetEntitlementByPaymentHash("hash-c1")
+	if e.TokensRemaining != 0 {
+		t.Errorf("remaining = %d, want 0", e.TokensRemaining)
+	}
+}
+
+func TestEntitlement_ConsumeRejectsOverdraw(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-od", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-od")
+	s.InsertEntitlement("ent-od", "hash-od", 5, 100_000_000, "key-1")
+
+	// Try to consume more than available.
+	err := s.ConsumeEntitlement("ent-od", 6)
+	if err == nil {
+		t.Fatal("expected error for overdraw")
+	}
+
+	// Verify remaining unchanged.
+	e, _ := s.GetEntitlementByPaymentHash("hash-od")
+	if e.TokensRemaining != 5 {
+		t.Errorf("remaining = %d after rejected overdraw, want 5", e.TokensRemaining)
+	}
+}
+
+func TestEntitlement_ImmutableFields(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-imm", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-imm")
+	s.InsertEntitlement("ent-imm", "hash-imm", 10, 100_000_000, "key-1")
+
+	// Try to modify bytes_per_token.
+	_, err := s.db.Exec(`UPDATE entitlements SET bytes_per_token = 999 WHERE id = 'ent-imm'`)
+	if err == nil {
+		t.Fatal("expected trigger to block bytes_per_token change")
+	}
+}
+
+func TestEntitlement_NoDeletion(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-nd", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-nd")
+	s.InsertEntitlement("ent-nd", "hash-nd", 10, 100_000_000, "key-1")
+
+	_, err := s.db.Exec(`DELETE FROM entitlements WHERE id = 'ent-nd'`)
+	if err == nil {
+		t.Fatal("expected trigger to block deletion")
+	}
+}
+
+// ============================================================
+// Phase 4: Spent token tests
+// ============================================================
+
+func TestSpentToken_MarkSpent_FirstSpend(t *testing.T) {
+	s := testStore(t)
+
+	first, err := s.MarkSpent("token-1", "key-1", "node-abc")
+	if err != nil {
+		t.Fatalf("MarkSpent: %v", err)
+	}
+	if !first {
+		t.Fatal("expected first_spend=true")
+	}
+}
+
+func TestSpentToken_MarkSpent_DoubleSpend(t *testing.T) {
+	s := testStore(t)
+
+	s.MarkSpent("token-ds", "key-1", "node-a")
+
+	// Second spend of same token — should return false.
+	first, err := s.MarkSpent("token-ds", "key-1", "node-b")
+	if err != nil {
+		t.Fatalf("MarkSpent double: %v", err)
+	}
+	if first {
+		t.Fatal("expected first_spend=false for double spend")
+	}
+}
+
+func TestSpentToken_IsSpent(t *testing.T) {
+	s := testStore(t)
+
+	spent, _ := s.IsSpent("token-x")
+	if spent {
+		t.Fatal("unspent token reported as spent")
+	}
+
+	s.MarkSpent("token-x", "key-1", "node-a")
+
+	spent, _ = s.IsSpent("token-x")
+	if !spent {
+		t.Fatal("spent token reported as unspent")
+	}
+}
+
+func TestSpentToken_NoDeletion(t *testing.T) {
+	s := testStore(t)
+	s.MarkSpent("token-del", "key-1", "node-a")
+
+	_, err := s.db.Exec(`DELETE FROM spent_tokens WHERE token_id = 'token-del'`)
+	if err == nil {
+		t.Fatal("expected trigger to block deletion")
+	}
+}
+
+func TestSpentToken_NoUpdate(t *testing.T) {
+	s := testStore(t)
+	s.MarkSpent("token-upd", "key-1", "node-a")
+
+	_, err := s.db.Exec(`UPDATE spent_tokens SET node_pubkey = 'node-b' WHERE token_id = 'token-upd'`)
+	if err == nil {
+		t.Fatal("expected trigger to block update")
+	}
+}
+
+// ============================================================
+// Phase 4: Redemption cache tests
+// ============================================================
+
+func TestRedemption_InsertAndGet(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-r1", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-r1")
+	s.InsertEntitlement("ent-r1", "hash-r1", 10, 100_000_000, "key-1")
+
+	err := s.InsertRedemption("nonce-1", "ent-r1", "reqhash-abc", 5, `["sig1","sig2"]`)
+	if err != nil {
+		t.Fatalf("InsertRedemption: %v", err)
+	}
+
+	r, err := s.GetRedemption("nonce-1")
+	if err != nil {
+		t.Fatalf("GetRedemption: %v", err)
+	}
+	if r.EntitlementID != "ent-r1" {
+		t.Errorf("entitlement_id = %s", r.EntitlementID)
+	}
+	if r.TokensCount != 5 {
+		t.Errorf("tokens_count = %d", r.TokensCount)
+	}
+	if r.RequestHash != "reqhash-abc" {
+		t.Errorf("request_hash = %s", r.RequestHash)
+	}
+}
+
+func TestRedemption_NotFound(t *testing.T) {
+	s := testStore(t)
+
+	r, err := s.GetRedemption("nonexistent")
+	if err != nil {
+		t.Fatalf("GetRedemption: %v", err)
+	}
+	if r != nil {
+		t.Fatal("expected nil for nonexistent nonce")
+	}
+}
+
+func TestRedemption_NoDeletion(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-rd", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-rd")
+	s.InsertEntitlement("ent-rd", "hash-rd", 10, 100_000_000, "key-1")
+	s.InsertRedemption("nonce-rd", "ent-rd", "rh", 1, `["sig"]`)
+
+	_, err := s.db.Exec(`DELETE FROM redemptions WHERE nonce = 'nonce-rd'`)
+	if err == nil {
+		t.Fatal("expected trigger to block deletion")
+	}
+}
+
+func TestRedemption_NoUpdate(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-ru", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-ru")
+	s.InsertEntitlement("ent-ru", "hash-ru", 10, 100_000_000, "key-1")
+	s.InsertRedemption("nonce-ru", "ent-ru", "rh", 1, `["sig"]`)
+
+	_, err := s.db.Exec(`UPDATE redemptions SET tokens_count = 99 WHERE nonce = 'nonce-ru'`)
+	if err == nil {
+		t.Fatal("expected trigger to block update")
+	}
+}
+
+// ============================================================
+// Phase 4 STRIDE: Concurrent entitlement consumption
+// ============================================================
+
+func TestSTRIDE_ConcurrentConsumeEntitlement(t *testing.T) {
+	s := testStore(t)
+	s.InsertInvoice("hash-cc", "lnbc...", 500, "1gb", 1_000_000_000,
+		time.Now().Add(time.Hour), "")
+	s.SettleInvoice("hash-cc")
+	s.InsertEntitlement("ent-cc", "hash-cc", 10, 100_000_000, "key-1")
+
+	// 20 goroutines each try to consume 1 token.
+	// Exactly 10 should succeed, 10 should fail.
+	var wg sync.WaitGroup
+	successes := int32(0)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := s.ConsumeEntitlement("ent-cc", 1); err == nil {
+				atomic.AddInt32(&successes, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successes != 10 {
+		t.Errorf("expected exactly 10 successes, got %d", successes)
+	}
+
+	e, _ := s.GetEntitlementByPaymentHash("hash-cc")
+	if e.TokensRemaining != 0 {
+		t.Errorf("remaining = %d, want 0", e.TokensRemaining)
+	}
+}
+
+func TestSTRIDE_ConcurrentMarkSpent(t *testing.T) {
+	s := testStore(t)
+
+	// 20 goroutines race to spend the same token.
+	// Exactly 1 should win.
+	var wg sync.WaitGroup
+	wins := int32(0)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			first, err := s.MarkSpent("race-token", "key-1", fmt.Sprintf("node-%d", idx))
+			if err == nil && first {
+				atomic.AddInt32(&wins, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if wins != 1 {
+		t.Errorf("expected exactly 1 winner, got %d", wins)
 	}
 }


### PR DESCRIPTION
## Summary

Implements Chaumian ecash-style RSA blind signatures for bandwidth tokens, achieving buyer-session unlinkability. The Hub signs blinded messages without seeing token secrets, making it mathematically impossible to link token usage back to the buyer.

**System model:** Online bounded-risk authorization for bandwidth — NOT offline ecash. Nodes verify signatures locally, then check spent status with the Hub.

## What changed

### New files
- `internal/credentials/blind.go` — RSA blind sig crypto (BlindMint, BlindVerifier, client helpers)
- `internal/credentials/blind_test.go` — 14 crypto tests
- `internal/payments/blind_api.go` — POST /redeem and POST /spend endpoints
- `internal/payments/blind_api_test.go` — 20 endpoint tests
- `internal/payments/blind_stride_test.go` — 14 STRIDE adversarial tests

### Modified files
- `internal/store/schema.go` — entitlements, spent_tokens, redemptions tables
- `internal/store/repository.go` — atomic ConsumeEntitlement, MarkSpent, InsertRedemption
- `internal/store/store_test.go` — 19 new store tests including concurrent STRIDE
- `internal/payments/api.go` — BlindMint/BlindVerifier fields, settlement creates entitlements
- `internal/lightning/mock.go` — proper preimage→hash pairs, GetPreimage()
- `.notes/decisions.md` — decisions 65-77

## Key design decisions

1. **Preimage authentication** — /redeem requires the Lightning payment preimage (SHA256(preimage) == payment_hash). Only the payer knows it.
2. **Consume before sign** — tokens are atomically consumed BEFORE blind signing. No free tokens on crash.
3. **Nonce idempotency** — /redeem caches (nonce, request_hash, signatures) for crash recovery.
4. **Atomic double-spend** — MarkSpent uses INSERT ON CONFLICT DO NOTHING, never separate check+insert.
5. **first_spend flag** — /spend returns {first_spend: bool}, not an error on double-spend. Nodes decide policy.
6. **Denomination-keyed** — Each RSA key maps to fixed bytes_per_token. Immutable once tokens issued.
7. **Domain-separated token ID** — SHA256("ARFL|v1|{key_id}|{secret_hex}") prevents cross-version collisions.

## API flow
```
POST /purchase → invoice → pay → settlement creates entitlement
POST /redeem   → preimage auth → consume tokens → blind sign → return signatures
POST /spend    → verify signature → atomic MarkSpent → return {first_spend, bytes}
```

## Test coverage
- 330 total tests, all passing with `-race`
- 14 STRIDE tests covering: spoofing, tampering, repudiation, DoS, elevation, concurrent races, info disclosure, replay resistance

## Grant relevance (HRF / OpenSats)
- Working code with STRIDE analysis — uncommon rigor
- Honest privacy claim: "online bounded-risk authorization" with documented bounds
- Bitcoin-native: Lightning payments + ecash primitives
- Open source, auditable