### PR TITLE
feat(phase6): LND Lightning adapter via REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,13 @@ target
 #.idea/
 .DS_Store
 
-# Local dev notes (tracked, protected by CODEOWNERS)
+# Binaries
 arfl-hub
+arfl-node
+arfl-client
+
+# Config files (may contain secrets)
+hub.json
+node.json
+*.macaroon
+keys/

--- a/cmd/arfl-hub/main.go
+++ b/cmd/arfl-hub/main.go
@@ -120,9 +120,27 @@ func main() {
 	issuer := credentials.NewHMACIssuer("key-1", credKey)
 
 	// Initialize Lightning client.
-	// Phase 3: mock client for development. Real LND adapter in production.
-	lnc := lightning.NewMockClient()
-	log.Printf("[hub] lightning: mock client (development mode)")
+	var lnc lightning.Client
+	if cfg.LNDHost != "" && cfg.LNDPort > 0 {
+		lndClient, err := lightning.NewLNDClient(lightning.LNDConfig{
+			Host:         cfg.LNDHost,
+			Port:         cfg.LNDPort,
+			TLSCertPath:  cfg.LNDTLSCertPath,
+			MacaroonPath: cfg.LNDMacaroonPath,
+			FeeLimitSat:  cfg.LNDFeeLimitSat,
+		})
+		if err != nil {
+			log.Fatalf("connect to LND: %v", err)
+		}
+		lnc = lndClient
+		log.Printf("[hub] lightning: LND at %s:%d", cfg.LNDHost, cfg.LNDPort)
+	} else {
+		if !*devMode {
+			log.Fatalf("LND config required (lnd_host, lnd_port, lnd_tls_cert_path, lnd_macaroon_path) — use --dev for mock")
+		}
+		lnc = lightning.NewMockClient()
+		log.Printf("[hub] lightning: mock client (--dev mode)")
+	}
 
 	// Create payment API.
 	purchaseAPI := payments.NewPurchaseAPI(db, lnc, issuer)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
+)
+
+// Environment variable names for sensitive configuration.
+// These override JSON config values when set, keeping secrets out of files.
+const (
+	EnvLNDHost         = "ARFL_LND_HOST"
+	EnvLNDPort         = "ARFL_LND_PORT"
+	EnvLNDTLSCertPath  = "ARFL_LND_TLS_CERT_PATH"
+	EnvLNDMacaroonPath = "ARFL_LND_MACAROON_PATH"
+	EnvLNDFeeLimitSat  = "ARFL_LND_FEE_LIMIT_SAT"
+	EnvCredentialKey   = "ARFL_CREDENTIAL_KEY"
+	EnvNostrPrivkey    = "ARFL_NOSTR_PRIVKEY"
+	EnvDBPath          = "ARFL_DB_PATH"
 )
 
 // NodeConfig holds configuration for an ARFL node daemon.
@@ -80,7 +94,45 @@ func LoadNodeConfig(path string) (*NodeConfig, error) {
 }
 
 func LoadHubConfig(path string) (*HubConfig, error) {
-	return loadJSON[HubConfig](path)
+	cfg, err := loadJSON[HubConfig](path)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ApplyEnv()
+	return cfg, nil
+}
+
+// ApplyEnv overrides config fields with environment variables when set.
+// Priority: env var > JSON config file. This keeps secrets out of config files.
+func (c *HubConfig) ApplyEnv() {
+	if v := os.Getenv(EnvLNDHost); v != "" {
+		c.LNDHost = v
+	}
+	if v := os.Getenv(EnvLNDPort); v != "" {
+		if port, err := strconv.Atoi(v); err == nil {
+			c.LNDPort = port
+		}
+	}
+	if v := os.Getenv(EnvLNDTLSCertPath); v != "" {
+		c.LNDTLSCertPath = v
+	}
+	if v := os.Getenv(EnvLNDMacaroonPath); v != "" {
+		c.LNDMacaroonPath = v
+	}
+	if v := os.Getenv(EnvLNDFeeLimitSat); v != "" {
+		if limit, err := strconv.ParseInt(v, 10, 64); err == nil {
+			c.LNDFeeLimitSat = limit
+		}
+	}
+	if v := os.Getenv(EnvCredentialKey); v != "" {
+		c.CredentialKey = v
+	}
+	if v := os.Getenv(EnvNostrPrivkey); v != "" {
+		c.NostrPrivkey = v
+	}
+	if v := os.Getenv(EnvDBPath); v != "" {
+		c.DBPath = v
+	}
 }
 
 func LoadClientConfig(path string) (*ClientConfig, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,13 @@ type HubConfig struct {
 
 	// Phase 4: Blind signatures
 	BlindKeyDir string `json:"blind_key_dir"` // Directory for RSA denomination keys (default: "keys/")
+
+	// Phase 6: LND connection (omit for mock/dev mode)
+	LNDHost         string `json:"lnd_host"`          // LND REST host (e.g. "localhost")
+	LNDPort         int    `json:"lnd_port"`          // LND REST port (e.g. 8080)
+	LNDTLSCertPath  string `json:"lnd_tls_cert_path"` // Path to LND's tls.cert
+	LNDMacaroonPath string `json:"lnd_macaroon_path"` // Path to admin.macaroon
+	LNDFeeLimitSat  int64  `json:"lnd_fee_limit_sat"` // Max routing fee per payment (default: 100)
 }
 
 // ClientConfig holds configuration for the ARFL client.

--- a/internal/lightning/lnd.go
+++ b/internal/lightning/lnd.go
@@ -1,0 +1,474 @@
+package lightning
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// LNDConfig holds connection details for an LND node.
+type LNDConfig struct {
+	Host         string // e.g. "localhost"
+	Port         int    // e.g. 8080 (REST port)
+	TLSCertPath  string // path to tls.cert
+	MacaroonPath string // path to admin.macaroon
+	FeeLimitSat  int64  // max routing fee in sats (default 100)
+}
+
+// LNDClient connects to an LND node via its REST API.
+// Uses macaroon authentication and TLS from LND's self-signed cert.
+type LNDClient struct {
+	baseURL     string
+	macaroonHex string
+	httpClient  *http.Client
+	feeLimitSat int64
+}
+
+// NewLNDClient creates a lightning.Client backed by a real LND node.
+func NewLNDClient(cfg LNDConfig) (*LNDClient, error) {
+	// Read TLS certificate.
+	certPEM, err := os.ReadFile(cfg.TLSCertPath)
+	if err != nil {
+		return nil, fmt.Errorf("read TLS cert %s: %w", cfg.TLSCertPath, err)
+	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(certPEM) {
+		return nil, fmt.Errorf("failed to parse TLS cert from %s", cfg.TLSCertPath)
+	}
+
+	// Read macaroon.
+	macBytes, err := os.ReadFile(cfg.MacaroonPath)
+	if err != nil {
+		return nil, fmt.Errorf("read macaroon %s: %w", cfg.MacaroonPath, err)
+	}
+	macaroonHex := hex.EncodeToString(macBytes)
+
+	feeLimitSat := cfg.FeeLimitSat
+	if feeLimitSat <= 0 {
+		feeLimitSat = 100
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: certPool,
+			},
+		},
+		Timeout: 30 * time.Second,
+	}
+
+	return &LNDClient{
+		baseURL:     fmt.Sprintf("https://%s:%d", cfg.Host, cfg.Port),
+		macaroonHex: macaroonHex,
+		httpClient:  client,
+		feeLimitSat: feeLimitSat,
+	}, nil
+}
+
+// newLNDClientDirect creates a client from pre-configured components (for tests).
+func newLNDClientDirect(baseURL, macaroonHex string, httpClient *http.Client) *LNDClient {
+	return &LNDClient{
+		baseURL:     baseURL,
+		macaroonHex: macaroonHex,
+		httpClient:  httpClient,
+		feeLimitSat: 100,
+	}
+}
+
+// CreateInvoice generates a BOLT11 payment request via LND.
+func (c *LNDClient) CreateInvoice(ctx context.Context, amountSats int64, memo string, expiry time.Duration) (*Invoice, error) {
+	body := map[string]interface{}{
+		"value":  amountSats,
+		"memo":   memo,
+		"expiry": int64(expiry.Seconds()),
+	}
+
+	var resp lndAddInvoiceResponse
+	if err := c.post(ctx, "/v1/invoices", body, &resp); err != nil {
+		return nil, fmt.Errorf("create invoice: %w", err)
+	}
+
+	paymentHash := base64ToHex(resp.RHash)
+
+	now := time.Now()
+	return &Invoice{
+		PaymentHash:    paymentHash,
+		PaymentRequest: resp.PaymentRequest,
+		AmountSats:     amountSats,
+		Memo:           memo,
+		Status:         InvoiceOpen,
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(expiry),
+	}, nil
+}
+
+// LookupInvoice checks the current status of an invoice by payment hash.
+func (c *LNDClient) LookupInvoice(ctx context.Context, paymentHash string) (*Invoice, error) {
+	// LND REST expects the hash as URL-safe base64 in the path.
+	hashBytes, err := hex.DecodeString(paymentHash)
+	if err != nil {
+		return nil, fmt.Errorf("invalid payment hash: %w", err)
+	}
+	hashB64 := base64.URLEncoding.EncodeToString(hashBytes)
+
+	var resp lndInvoice
+	if err := c.get(ctx, "/v1/invoice/"+hashB64, &resp); err != nil {
+		if strings.Contains(err.Error(), "unable to locate invoice") {
+			return nil, ErrInvoiceNotFound
+		}
+		return nil, fmt.Errorf("lookup invoice: %w", err)
+	}
+
+	return lndInvoiceToInvoice(&resp), nil
+}
+
+// SubscribeInvoices opens a streaming connection to LND's invoice subscription.
+// Emits only settled invoices. Reconnects on connection drops.
+func (c *LNDClient) SubscribeInvoices(ctx context.Context) (<-chan *Invoice, error) {
+	ch := make(chan *Invoice, 64)
+
+	go func() {
+		defer close(ch)
+		for {
+			if err := c.subscribeLoop(ctx, ch); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Printf("[lnd] subscribe stream error: %v — reconnecting in 5s", err)
+				select {
+				case <-time.After(5 * time.Second):
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (c *LNDClient) subscribeLoop(ctx context.Context, ch chan<- *Invoice) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/v1/invoices/subscribe", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Grpc-Metadata-macaroon", c.macaroonHex)
+
+	// Use a client without timeout for streaming.
+	streamClient := *c.httpClient
+	streamClient.Timeout = 0
+
+	resp, err := streamClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("subscribe request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("subscribe: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	// LND can send large invoice payloads.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var wrapper lndStreamWrapper
+		if err := json.Unmarshal([]byte(line), &wrapper); err != nil {
+			log.Printf("[lnd] subscribe: unmarshal error: %v", err)
+			continue
+		}
+
+		if wrapper.Result.State == "SETTLED" {
+			inv := lndInvoiceToInvoice(&wrapper.Result)
+			select {
+			case ch <- inv:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("subscribe scanner: %w", err)
+	}
+	return fmt.Errorf("subscribe stream ended")
+}
+
+// SendPayment pays a BOLT11 invoice via LND's router.
+func (c *LNDClient) SendPayment(ctx context.Context, paymentRequest string, amountSats int64) (*PaymentResult, error) {
+	body := map[string]interface{}{
+		"payment_request":     paymentRequest,
+		"timeout_seconds":     60,
+		"fee_limit_sat":       c.feeLimitSat,
+		"no_inflight_updates": true,
+	}
+
+	return c.sendPaymentV2(ctx, body)
+}
+
+// Keysend sends a spontaneous payment to a node by public key.
+func (c *LNDClient) Keysend(ctx context.Context, destPubkey string, amountSats int64) (*PaymentResult, error) {
+	destBytes, err := hex.DecodeString(destPubkey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dest pubkey: %w", err)
+	}
+
+	// Generate a random preimage for keysend.
+	preimage := make([]byte, 32)
+	if _, err := io.ReadFull(strings.NewReader(randomHex()[:64]), preimage); err != nil {
+		return nil, err
+	}
+	// Actually use crypto/rand properly.
+	preimageHex, _, err := randomPreimageHash()
+	if err != nil {
+		return nil, err
+	}
+	preimageBytes, _ := hex.DecodeString(preimageHex)
+
+	body := map[string]interface{}{
+		"dest":                base64.StdEncoding.EncodeToString(destBytes),
+		"amt":                 amountSats,
+		"timeout_seconds":     60,
+		"fee_limit_sat":       c.feeLimitSat,
+		"no_inflight_updates": true,
+		"dest_custom_records": map[string]string{
+			// TLV type 5482373484 is the keysend preimage record.
+			"5482373484": base64.StdEncoding.EncodeToString(preimageBytes),
+		},
+	}
+
+	return c.sendPaymentV2(ctx, body)
+}
+
+// sendPaymentV2 calls the v2/router/send streaming endpoint and collects the final status.
+func (c *LNDClient) sendPaymentV2(ctx context.Context, body map[string]interface{}) (*PaymentResult, error) {
+	data, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/v2/router/send", strings.NewReader(string(data)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Grpc-Metadata-macaroon", c.macaroonHex)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send payment: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("send payment: HTTP %d: %s", resp.StatusCode, errBody)
+	}
+
+	// v2/router/send is a server-streaming endpoint.
+	// Read all lines and use the final payment status.
+	var lastPayment lndPayment
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var wrapper struct {
+			Result lndPayment `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(line), &wrapper); err != nil {
+			continue
+		}
+		lastPayment = wrapper.Result
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("payment stream: %w", err)
+	}
+
+	result := &PaymentResult{
+		PaymentHash: base64ToHex(lastPayment.PaymentHash),
+	}
+
+	switch lastPayment.Status {
+	case "SUCCEEDED":
+		result.Status = PaymentSucceeded
+	case "FAILED":
+		result.Status = PaymentFailed
+		result.Error = lastPayment.FailureReason
+		if result.Error == "" {
+			result.Error = "payment failed"
+		}
+	case "IN_FLIGHT":
+		result.Status = PaymentInFlight
+	default:
+		result.Status = PaymentFailed
+		result.Error = fmt.Sprintf("unexpected status: %s", lastPayment.Status)
+	}
+
+	// Parse fee from the response.
+	if lastPayment.FeeSat != "" {
+		fmt.Sscanf(lastPayment.FeeSat, "%d", &result.FeeSats)
+	}
+
+	return result, nil
+}
+
+// --- HTTP helpers ---
+
+func (c *LNDClient) post(ctx context.Context, path string, body interface{}, out interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+path, strings.NewReader(string(data)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Grpc-Metadata-macaroon", c.macaroonHex)
+	req.Header.Set("Content-Type", "application/json")
+
+	return c.doJSON(req, out)
+}
+
+func (c *LNDClient) get(ctx context.Context, path string, out interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Grpc-Metadata-macaroon", c.macaroonHex)
+
+	return c.doJSON(req, out)
+}
+
+func (c *LNDClient) doJSON(req *http.Request, out interface{}) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Try to extract LND error message.
+		var lndErr struct {
+			Message string `json:"message"`
+			Error   string `json:"error"`
+		}
+		json.Unmarshal(body, &lndErr)
+		msg := lndErr.Message
+		if msg == "" {
+			msg = lndErr.Error
+		}
+		if msg == "" {
+			msg = string(body)
+		}
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, msg)
+	}
+
+	return json.Unmarshal(body, out)
+}
+
+// --- LND REST API response types ---
+
+type lndAddInvoiceResponse struct {
+	RHash          string `json:"r_hash"`
+	PaymentRequest string `json:"payment_request"`
+	AddIndex       string `json:"add_index"`
+}
+
+type lndInvoice struct {
+	Memo           string `json:"memo"`
+	RHash          string `json:"r_hash"`
+	Value          string `json:"value"`
+	State          string `json:"state"` // OPEN, SETTLED, CANCELLED, ACCEPTED
+	CreationDate   string `json:"creation_date"`
+	SettleDate     string `json:"settle_date"`
+	Expiry         string `json:"expiry"`
+	PaymentRequest string `json:"payment_request"`
+}
+
+type lndStreamWrapper struct {
+	Result lndInvoice `json:"result"`
+}
+
+type lndPayment struct {
+	PaymentHash   string `json:"payment_hash"`
+	Status        string `json:"status"` // IN_FLIGHT, SUCCEEDED, FAILED
+	FeeSat        string `json:"fee_sat"`
+	FailureReason string `json:"failure_reason"`
+}
+
+// --- Conversion helpers ---
+
+func lndInvoiceToInvoice(lnd *lndInvoice) *Invoice {
+	inv := &Invoice{
+		PaymentHash:    base64ToHex(lnd.RHash),
+		PaymentRequest: lnd.PaymentRequest,
+		Memo:           lnd.Memo,
+	}
+
+	fmt.Sscanf(lnd.Value, "%d", &inv.AmountSats)
+
+	switch lnd.State {
+	case "SETTLED":
+		inv.Status = InvoiceSettled
+	case "CANCELLED", "CANCELED":
+		inv.Status = InvoiceExpired
+	default:
+		inv.Status = InvoiceOpen
+	}
+
+	if lnd.CreationDate != "" {
+		var ts int64
+		fmt.Sscanf(lnd.CreationDate, "%d", &ts)
+		inv.CreatedAt = time.Unix(ts, 0)
+	}
+	if lnd.SettleDate != "" && lnd.SettleDate != "0" {
+		var ts int64
+		fmt.Sscanf(lnd.SettleDate, "%d", &ts)
+		inv.SettledAt = time.Unix(ts, 0)
+	}
+	if lnd.Expiry != "" && lnd.CreationDate != "" {
+		var created, expiry int64
+		fmt.Sscanf(lnd.CreationDate, "%d", &created)
+		fmt.Sscanf(lnd.Expiry, "%d", &expiry)
+		inv.ExpiresAt = time.Unix(created+expiry, 0)
+	}
+
+	return inv
+}
+
+// base64ToHex converts a base64 (standard or URL-safe) string to hex.
+// Returns the input unchanged if decoding fails.
+func base64ToHex(b64 string) string {
+	// Try standard base64 first, then URL-safe.
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		data, err = base64.URLEncoding.DecodeString(b64)
+		if err != nil {
+			// Might already be hex.
+			return b64
+		}
+	}
+	return hex.EncodeToString(data)
+}

--- a/internal/lightning/lnd.go
+++ b/internal/lightning/lnd.go
@@ -130,7 +130,7 @@ func (c *LNDClient) LookupInvoice(ctx context.Context, paymentHash string) (*Inv
 		return nil, fmt.Errorf("lookup invoice: %w", err)
 	}
 
-	return lndInvoiceToInvoice(&resp), nil
+	return lndInvoiceToInvoice(&resp)
 }
 
 // SubscribeInvoices opens a streaming connection to LND's invoice subscription.
@@ -192,12 +192,16 @@ func (c *LNDClient) subscribeLoop(ctx context.Context, ch chan<- *Invoice) error
 
 		var wrapper lndStreamWrapper
 		if err := json.Unmarshal([]byte(line), &wrapper); err != nil {
-			log.Printf("[lnd] subscribe: unmarshal error: %v", err)
-			continue
+			// Don't silently drop — return error to trigger reconnection.
+			// A malformed line likely means a protocol issue.
+			return fmt.Errorf("unmarshal invoice event: %w", err)
 		}
 
 		if wrapper.Result.State == "SETTLED" {
-			inv := lndInvoiceToInvoice(&wrapper.Result)
+			inv, err := lndInvoiceToInvoice(&wrapper.Result)
+			if err != nil {
+				return fmt.Errorf("parse settled invoice: %w", err)
+			}
 			select {
 			case ch <- inv:
 			case <-ctx.Done():
@@ -232,16 +236,14 @@ func (c *LNDClient) Keysend(ctx context.Context, destPubkey string, amountSats i
 	}
 
 	// Generate a random preimage for keysend.
-	preimage := make([]byte, 32)
-	if _, err := io.ReadFull(strings.NewReader(randomHex()[:64]), preimage); err != nil {
-		return nil, err
-	}
-	// Actually use crypto/rand properly.
 	preimageHex, _, err := randomPreimageHash()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("generate keysend preimage: %w", err)
 	}
-	preimageBytes, _ := hex.DecodeString(preimageHex)
+	preimageBytes, err := hex.DecodeString(preimageHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode keysend preimage: %w", err)
+	}
 
 	body := map[string]interface{}{
 		"dest":                base64.StdEncoding.EncodeToString(destBytes),
@@ -260,7 +262,10 @@ func (c *LNDClient) Keysend(ctx context.Context, destPubkey string, amountSats i
 
 // sendPaymentV2 calls the v2/router/send streaming endpoint and collects the final status.
 func (c *LNDClient) sendPaymentV2(ctx context.Context, body map[string]interface{}) (*PaymentResult, error) {
-	data, _ := json.Marshal(body)
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal payment request: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/v2/router/send", strings.NewReader(string(data)))
 	if err != nil {
 		return nil, err
@@ -320,9 +325,10 @@ func (c *LNDClient) sendPaymentV2(ctx context.Context, body map[string]interface
 		result.Error = fmt.Sprintf("unexpected status: %s", lastPayment.Status)
 	}
 
-	// Parse fee from the response.
 	if lastPayment.FeeSat != "" {
-		fmt.Sscanf(lastPayment.FeeSat, "%d", &result.FeeSats)
+		if _, err := fmt.Sscanf(lastPayment.FeeSat, "%d", &result.FeeSats); err != nil {
+			log.Printf("[lnd] warning: could not parse fee %q: %v", lastPayment.FeeSat, err)
+		}
 	}
 
 	return result, nil
@@ -420,14 +426,18 @@ type lndPayment struct {
 
 // --- Conversion helpers ---
 
-func lndInvoiceToInvoice(lnd *lndInvoice) *Invoice {
+func lndInvoiceToInvoice(lnd *lndInvoice) (*Invoice, error) {
 	inv := &Invoice{
 		PaymentHash:    base64ToHex(lnd.RHash),
 		PaymentRequest: lnd.PaymentRequest,
 		Memo:           lnd.Memo,
 	}
 
-	fmt.Sscanf(lnd.Value, "%d", &inv.AmountSats)
+	if lnd.Value != "" {
+		if _, err := fmt.Sscanf(lnd.Value, "%d", &inv.AmountSats); err != nil {
+			return nil, fmt.Errorf("parse invoice amount %q: %w", lnd.Value, err)
+		}
+	}
 
 	switch lnd.State {
 	case "SETTLED":
@@ -440,22 +450,28 @@ func lndInvoiceToInvoice(lnd *lndInvoice) *Invoice {
 
 	if lnd.CreationDate != "" {
 		var ts int64
-		fmt.Sscanf(lnd.CreationDate, "%d", &ts)
+		if _, err := fmt.Sscanf(lnd.CreationDate, "%d", &ts); err != nil {
+			return nil, fmt.Errorf("parse creation_date %q: %w", lnd.CreationDate, err)
+		}
 		inv.CreatedAt = time.Unix(ts, 0)
 	}
 	if lnd.SettleDate != "" && lnd.SettleDate != "0" {
 		var ts int64
-		fmt.Sscanf(lnd.SettleDate, "%d", &ts)
+		if _, err := fmt.Sscanf(lnd.SettleDate, "%d", &ts); err != nil {
+			return nil, fmt.Errorf("parse settle_date %q: %w", lnd.SettleDate, err)
+		}
 		inv.SettledAt = time.Unix(ts, 0)
 	}
 	if lnd.Expiry != "" && lnd.CreationDate != "" {
 		var created, expiry int64
-		fmt.Sscanf(lnd.CreationDate, "%d", &created)
-		fmt.Sscanf(lnd.Expiry, "%d", &expiry)
+		fmt.Sscanf(lnd.CreationDate, "%d", &created) // already validated above
+		if _, err := fmt.Sscanf(lnd.Expiry, "%d", &expiry); err != nil {
+			return nil, fmt.Errorf("parse expiry %q: %w", lnd.Expiry, err)
+		}
 		inv.ExpiresAt = time.Unix(created+expiry, 0)
 	}
 
-	return inv
+	return inv, nil
 }
 
 // base64ToHex converts a base64 (standard or URL-safe) string to hex.

--- a/internal/lightning/lnd_test.go
+++ b/internal/lightning/lnd_test.go
@@ -1,0 +1,541 @@
+package lightning
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeLND is a test double that simulates LND's REST API.
+type fakeLND struct {
+	mu       sync.Mutex
+	invoices map[string]lndInvoice // r_hash (base64) → invoice
+	macaroon string                // expected macaroon hex
+
+	// Track subscribe connections for test control.
+	subWriters []http.ResponseWriter
+	subFlush   []http.Flusher
+}
+
+func newFakeLND(macaroon string) *fakeLND {
+	return &fakeLND{
+		invoices: make(map[string]lndInvoice),
+		macaroon: macaroon,
+	}
+}
+
+func (f *fakeLND) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/invoices", f.handleAddInvoice)
+	mux.HandleFunc("/v1/invoice/", f.handleLookupInvoice)
+	mux.HandleFunc("/v1/invoices/subscribe", f.handleSubscribe)
+	mux.HandleFunc("/v2/router/send", f.handleSendPayment)
+	return mux
+}
+
+func (f *fakeLND) checkMacaroon(w http.ResponseWriter, r *http.Request) bool {
+	mac := r.Header.Get("Grpc-Metadata-macaroon")
+	if mac != f.macaroon {
+		http.Error(w, `{"error":"permission denied","message":"invalid macaroon"}`, http.StatusUnauthorized)
+		return false
+	}
+	return true
+}
+
+func (f *fakeLND) handleAddInvoice(w http.ResponseWriter, r *http.Request) {
+	if !f.checkMacaroon(w, r) {
+		return
+	}
+	if r.Method != "POST" {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Value  json.Number `json:"value"`
+		Memo   string      `json:"memo"`
+		Expiry json.Number `json:"expiry"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Generate a deterministic hash from the memo for test predictability.
+	rHash := make([]byte, 32)
+	copy(rHash, []byte("test-hash-"+req.Memo))
+	rHashB64 := base64.StdEncoding.EncodeToString(rHash)
+
+	now := time.Now()
+	exp, _ := req.Expiry.Int64()
+
+	inv := lndInvoice{
+		Memo:           req.Memo,
+		RHash:          rHashB64,
+		Value:          req.Value.String(),
+		State:          "OPEN",
+		CreationDate:   fmt.Sprintf("%d", now.Unix()),
+		Expiry:         fmt.Sprintf("%d", exp),
+		PaymentRequest: "lnbcrt" + hex.EncodeToString(rHash[:8]),
+	}
+
+	f.mu.Lock()
+	f.invoices[rHashB64] = inv
+	f.mu.Unlock()
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"r_hash":          rHashB64,
+		"payment_request": inv.PaymentRequest,
+		"add_index":       "1",
+	})
+}
+
+func (f *fakeLND) handleLookupInvoice(w http.ResponseWriter, r *http.Request) {
+	if !f.checkMacaroon(w, r) {
+		return
+	}
+
+	// Extract hash from path: /v1/invoice/{r_hash_str}
+	parts := strings.Split(r.URL.Path, "/v1/invoice/")
+	if len(parts) < 2 || parts[1] == "" {
+		http.Error(w, `{"message":"unable to locate invoice"}`, http.StatusNotFound)
+		return
+	}
+	hashB64 := parts[1]
+
+	// URL-safe base64 → standard base64 for lookup.
+	hashBytes, err := base64.URLEncoding.DecodeString(hashB64)
+	if err != nil {
+		http.Error(w, `{"message":"unable to locate invoice"}`, http.StatusNotFound)
+		return
+	}
+	stdB64 := base64.StdEncoding.EncodeToString(hashBytes)
+
+	f.mu.Lock()
+	inv, ok := f.invoices[stdB64]
+	f.mu.Unlock()
+
+	if !ok {
+		http.Error(w, `{"message":"unable to locate invoice"}`, http.StatusNotFound)
+		return
+	}
+
+	json.NewEncoder(w).Encode(inv)
+}
+
+func (f *fakeLND) handleSubscribe(w http.ResponseWriter, r *http.Request) {
+	if !f.checkMacaroon(w, r) {
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	f.mu.Lock()
+	f.subWriters = append(f.subWriters, w)
+	f.subFlush = append(f.subFlush, flusher)
+	f.mu.Unlock()
+
+	// Block until context is cancelled.
+	<-r.Context().Done()
+}
+
+// settleInvoice simulates invoice settlement — notifies all subscribers.
+func (f *fakeLND) settleInvoice(rHashB64 string) {
+	f.mu.Lock()
+	inv, ok := f.invoices[rHashB64]
+	if ok {
+		inv.State = "SETTLED"
+		inv.SettleDate = fmt.Sprintf("%d", time.Now().Unix())
+		f.invoices[rHashB64] = inv
+	}
+
+	// Write to all subscriber streams.
+	for i, w := range f.subWriters {
+		line, _ := json.Marshal(map[string]interface{}{"result": inv})
+		fmt.Fprintf(w, "%s\n", line)
+		f.subFlush[i].Flush()
+	}
+	f.mu.Unlock()
+}
+
+func (f *fakeLND) handleSendPayment(w http.ResponseWriter, r *http.Request) {
+	if !f.checkMacaroon(w, r) {
+		return
+	}
+
+	var req map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&req)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Simulate a successful payment.
+	payHash := base64.StdEncoding.EncodeToString([]byte("payment-hash-result-000000000000"))
+
+	result := map[string]interface{}{
+		"result": map[string]interface{}{
+			"payment_hash": payHash,
+			"status":       "SUCCEEDED",
+			"fee_sat":      "2",
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	line, _ := json.Marshal(result)
+	fmt.Fprintf(w, "%s\n", line)
+	flusher.Flush()
+}
+
+// --- Test helpers ---
+
+func setupTestLND(t *testing.T) (*LNDClient, *fakeLND) {
+	t.Helper()
+	macaroon := "deadbeef1234"
+	fake := newFakeLND(macaroon)
+
+	srv := httptest.NewTLSServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	client := newLNDClientDirect(srv.URL, macaroon, srv.Client())
+	return client, fake
+}
+
+// --- Interface compliance ---
+
+func TestLNDClient_ImplementsClient(t *testing.T) {
+	var _ Client = (*LNDClient)(nil)
+}
+
+// --- CreateInvoice ---
+
+func TestLND_CreateInvoice_Success(t *testing.T) {
+	client, _ := setupTestLND(t)
+	ctx := context.Background()
+
+	inv, err := client.CreateInvoice(ctx, 500, "bandwidth-1gb", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("CreateInvoice: %v", err)
+	}
+	if inv.AmountSats != 500 {
+		t.Errorf("amount = %d, want 500", inv.AmountSats)
+	}
+	if inv.Memo != "bandwidth-1gb" {
+		t.Errorf("memo = %q, want %q", inv.Memo, "bandwidth-1gb")
+	}
+	if inv.Status != InvoiceOpen {
+		t.Errorf("status = %s, want open", inv.Status)
+	}
+	if inv.PaymentHash == "" {
+		t.Error("payment hash is empty")
+	}
+	if !strings.HasPrefix(inv.PaymentRequest, "lnbcrt") {
+		t.Errorf("payment request = %q, want lnbcrt prefix", inv.PaymentRequest)
+	}
+}
+
+func TestLND_CreateInvoice_BadMacaroon(t *testing.T) {
+	macaroon := "deadbeef1234"
+	fake := newFakeLND(macaroon)
+	srv := httptest.NewTLSServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	// Wrong macaroon.
+	client := newLNDClientDirect(srv.URL, "wrongmacaroon", srv.Client())
+
+	_, err := client.CreateInvoice(context.Background(), 500, "test", time.Minute)
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 error, got: %v", err)
+	}
+}
+
+// --- LookupInvoice ---
+
+func TestLND_LookupInvoice_Found(t *testing.T) {
+	client, _ := setupTestLND(t)
+	ctx := context.Background()
+
+	inv, err := client.CreateInvoice(ctx, 250, "lookup-test", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("CreateInvoice: %v", err)
+	}
+
+	found, err := client.LookupInvoice(ctx, inv.PaymentHash)
+	if err != nil {
+		t.Fatalf("LookupInvoice: %v", err)
+	}
+	if found.Memo != "lookup-test" {
+		t.Errorf("memo = %q, want %q", found.Memo, "lookup-test")
+	}
+	if found.Status != InvoiceOpen {
+		t.Errorf("status = %s, want open", found.Status)
+	}
+}
+
+func TestLND_LookupInvoice_NotFound(t *testing.T) {
+	client, _ := setupTestLND(t)
+
+	_, err := client.LookupInvoice(context.Background(), hex.EncodeToString(make([]byte, 32)))
+	if err != ErrInvoiceNotFound {
+		t.Fatalf("expected ErrInvoiceNotFound, got: %v", err)
+	}
+}
+
+func TestLND_LookupInvoice_Settled(t *testing.T) {
+	client, fake := setupTestLND(t)
+	ctx := context.Background()
+
+	inv, _ := client.CreateInvoice(ctx, 500, "settle-test", 5*time.Minute)
+
+	// Settle it server-side.
+	hashBytes, _ := hex.DecodeString(inv.PaymentHash)
+	rHashB64 := base64.StdEncoding.EncodeToString(hashBytes)
+	fake.settleInvoice(rHashB64)
+
+	found, err := client.LookupInvoice(ctx, inv.PaymentHash)
+	if err != nil {
+		t.Fatalf("LookupInvoice: %v", err)
+	}
+	if found.Status != InvoiceSettled {
+		t.Errorf("status = %s, want settled", found.Status)
+	}
+}
+
+// --- SubscribeInvoices ---
+
+func TestLND_SubscribeInvoices_ReceivesSettlement(t *testing.T) {
+	client, fake := setupTestLND(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := client.SubscribeInvoices(ctx)
+	if err != nil {
+		t.Fatalf("SubscribeInvoices: %v", err)
+	}
+
+	// Create and settle an invoice.
+	inv, _ := client.CreateInvoice(ctx, 500, "sub-test", 5*time.Minute)
+
+	// Give the subscribe goroutine time to connect.
+	time.Sleep(200 * time.Millisecond)
+
+	hashBytes, _ := hex.DecodeString(inv.PaymentHash)
+	rHashB64 := base64.StdEncoding.EncodeToString(hashBytes)
+	fake.settleInvoice(rHashB64)
+
+	select {
+	case settled := <-ch:
+		if settled == nil {
+			t.Fatal("received nil invoice")
+		}
+		if settled.Status != InvoiceSettled {
+			t.Errorf("status = %s, want settled", settled.Status)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for settlement")
+	}
+}
+
+func TestLND_SubscribeInvoices_ContextCancellation(t *testing.T) {
+	client, _ := setupTestLND(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch, err := client.SubscribeInvoices(ctx)
+	if err != nil {
+		t.Fatalf("SubscribeInvoices: %v", err)
+	}
+
+	// Give subscribe time to connect.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// Channel should close.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			// Might get a stale event, but eventually the channel closes.
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("channel did not close after context cancellation")
+	}
+}
+
+// --- SendPayment ---
+
+func TestLND_SendPayment_Success(t *testing.T) {
+	client, _ := setupTestLND(t)
+	ctx := context.Background()
+
+	result, err := client.SendPayment(ctx, "lnbcrt500...", 500)
+	if err != nil {
+		t.Fatalf("SendPayment: %v", err)
+	}
+	if result.Status != PaymentSucceeded {
+		t.Errorf("status = %s, want succeeded", result.Status)
+	}
+	if result.PaymentHash == "" {
+		t.Error("payment hash is empty")
+	}
+	if result.FeeSats != 2 {
+		t.Errorf("fee = %d, want 2", result.FeeSats)
+	}
+}
+
+func TestLND_SendPayment_BadMacaroon(t *testing.T) {
+	macaroon := "deadbeef1234"
+	fake := newFakeLND(macaroon)
+	srv := httptest.NewTLSServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	client := newLNDClientDirect(srv.URL, "wrong", srv.Client())
+
+	_, err := client.SendPayment(context.Background(), "lnbcrt500...", 500)
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+}
+
+func TestLND_SendPayment_ContextTimeout(t *testing.T) {
+	// Server that blocks until signalled (simulates slow LND).
+	done := make(chan struct{})
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-done:
+		}
+	}))
+	t.Cleanup(func() {
+		close(done)
+		srv.Close()
+	})
+
+	client := newLNDClientDirect(srv.URL, "mac", srv.Client())
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := client.SendPayment(ctx, "lnbcrt...", 500)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+// --- Keysend ---
+
+func TestLND_Keysend_Success(t *testing.T) {
+	client, _ := setupTestLND(t)
+	ctx := context.Background()
+
+	destPubkey := hex.EncodeToString(make([]byte, 33))
+	result, err := client.Keysend(ctx, destPubkey, 100)
+	if err != nil {
+		t.Fatalf("Keysend: %v", err)
+	}
+	if result.Status != PaymentSucceeded {
+		t.Errorf("status = %s, want succeeded", result.Status)
+	}
+}
+
+// --- SendPayment failure simulation ---
+
+func TestLND_SendPayment_Failed(t *testing.T) {
+	// Server returns a FAILED payment.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Grpc-Metadata-macaroon") == "" {
+			http.Error(w, "no auth", http.StatusUnauthorized)
+			return
+		}
+
+		flusher := w.(http.Flusher)
+		result := map[string]interface{}{
+			"result": map[string]interface{}{
+				"payment_hash":   base64.StdEncoding.EncodeToString(make([]byte, 32)),
+				"status":         "FAILED",
+				"failure_reason": "FAILURE_REASON_NO_ROUTE",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		line, _ := json.Marshal(result)
+		fmt.Fprintf(w, "%s\n", line)
+		flusher.Flush()
+	}))
+	t.Cleanup(srv.Close)
+
+	client := newLNDClientDirect(srv.URL, "mac", srv.Client())
+
+	result, err := client.SendPayment(context.Background(), "lnbcrt...", 500)
+	if err != nil {
+		t.Fatalf("SendPayment: %v (expected result, not error)", err)
+	}
+	if result.Status != PaymentFailed {
+		t.Errorf("status = %s, want failed", result.Status)
+	}
+	if result.Error == "" {
+		t.Error("expected error message on failed payment")
+	}
+}
+
+// --- base64ToHex helper ---
+
+func TestBase64ToHex(t *testing.T) {
+	// Standard base64.
+	data := []byte{0xde, 0xad, 0xbe, 0xef}
+	b64 := base64.StdEncoding.EncodeToString(data)
+	got := base64ToHex(b64)
+	want := "deadbeef"
+	if got != want {
+		t.Errorf("base64ToHex(%q) = %q, want %q", b64, got, want)
+	}
+
+	// URL-safe base64.
+	b64url := base64.URLEncoding.EncodeToString(data)
+	got2 := base64ToHex(b64url)
+	if got2 != want {
+		t.Errorf("base64ToHex(%q) = %q, want %q", b64url, got2, want)
+	}
+
+	// Already hex — returned unchanged.
+	got3 := base64ToHex("not-valid-base64!")
+	if got3 != "not-valid-base64!" {
+		t.Errorf("expected passthrough for non-base64")
+	}
+}
+
+// --- Connection refused ---
+
+func TestLND_CreateInvoice_ConnectionRefused(t *testing.T) {
+	client := newLNDClientDirect("https://127.0.0.1:1", "mac", &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		Timeout: 2 * time.Second,
+	})
+
+	_, err := client.CreateInvoice(context.Background(), 500, "test", time.Minute)
+	if err == nil {
+		t.Fatal("expected connection error")
+	}
+}


### PR DESCRIPTION
## What

Real LND integration replacing the hardcoded mock client. The hub now connects to an actual Lightning node for invoice creation, payment settlement, and node payouts.

## Changes

- **`internal/lightning/lnd.go`** — `LNDClient` implementing `lightning.Client` via LND REST API
  - `CreateInvoice` → `POST /v1/invoices`
  - `LookupInvoice` → `GET /v1/invoice/{hash}`
  - `SubscribeInvoices` → `GET /v1/invoices/subscribe` (streaming with auto-reconnect)
  - `SendPayment` → `POST /v2/router/send` (streaming, collects final status)
  - `Keysend` → `POST /v2/router/send` with TLV 5482373484 preimage record
  - Macaroon auth via `Grpc-Metadata-macaroon` header, TLS cert pinning

- **`internal/lightning/lnd_test.go`** — 15 tests using `httptest.NewTLSServer` as a fake LND
  - Auth validation, invoice CRUD, settlement streaming, payment success/failure, keysend, context timeout, connection refused

- **`internal/config/config.go`** — LND fields in `HubConfig`:
  - `lnd_host`, `lnd_port`, `lnd_tls_cert_path`, `lnd_macaroon_path`, `lnd_fee_limit_sat`

- **`cmd/arfl-hub/main.go`** — Auto-detect: LND config present → real client; absent + `--dev` → mock; absent without `--dev` → fatal error (prevents accidental production deployment with mock)

## Testing

408 tests across 10 packages, all passing with `-race`.

## Hub config example

```json
{
  "lnd_host": "localhost",
  "lnd_port": 8080,
  "lnd_tls_cert_path": "~/.lnd/tls.cert",
  "lnd_macaroon_path": "~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon",
  "lnd_fee_limit_sat": 100
}
```

## Next

Day 3: Docker Compose testnet (hub + 2 nodes + LND + Nostr relay)