### PR TITLE
feat: attestation system, node leases, deployment hardening

### DIFF
--- a/.notes/decisions.md
+++ b/.notes/decisions.md
@@ -1866,3 +1866,94 @@ and double-spend detection. Four tests cover:
 2. Multi-client independence (entitlement isolation)
 3. Key persistence round-trip (tokens survive key save/load)
 4. Unlinkability proof (blinded ≠ secret, mathematically)
+
+---
+
+### Decision 87: Attestation auto-refresh with 6-hour TTL
+
+**Context:** Attestations had a 6-hour TTL. When they expired, nodes silently
+dropped off the network. We initially changed to 30-day TTL but reverted because
+short TTLs are a security feature — a compromised key can only be used for hours,
+not months.
+
+**Decision:** Keep 6-hour TTL. Nodes auto-refresh by calling `POST /attest/refresh`
+on the hub when ≤1 hour remains. The node signs `SHA256(attestation_json + timestamp)`
+with its Nostr key. The hub verifies both the node's request signature AND its own
+original Schnorr signature on the attestation before re-issuing. 5-minute replay
+window on timestamps. Check runs every 60 seconds in the announcer loop.
+
+---
+
+### Decision 88: Attestation refresh security fix — verify hub's own signature
+
+**Context:** The initial refresh handler verified the node's request signature
+and checked the content hash, but did NOT verify the hub's BIP-340 Schnorr
+signature on the attestation itself. This meant an attacker could craft a fake
+attestation (claiming to be any node with any role) and get the hub to sign a
+real one — a critical signature forgery vulnerability.
+
+**Decision:** Added `VerifySignature()` method that checks everything except
+expiry (since we're about to extend it). The refresh handler now calls
+`VerifySignature()` before re-issuing. This ensures only attestations originally
+signed by this hub can be refreshed.
+
+---
+
+### Decision 89: Node lease system — time-bounded authorization
+
+**Context:** Auto-refresh solved the uptime problem but introduced a revocation
+gap: a compromised or misbehaving node could refresh indefinitely. We needed
+a mechanism to control which nodes are authorized to refresh.
+
+**Decision:** `node_leases` table in SQLite tracks authorization windows per node.
+Fields: node_pubkey (PK), operator_id, wg_pubkey, allowed_roles, lease_start,
+lease_end, revoked flag. The refresh endpoint checks `IsLeaseActive()` before
+re-issuing — rejects if revoked or expired. CLI subcommands:
+- `arfl-hub attest --lease 90d` creates attestation AND stores lease
+- `arfl-hub revoke --node-pubkey <hex>` sets revoked=1
+- `arfl-hub renew --node-pubkey <hex> --lease 90d` extends lease
+- `arfl-hub list-nodes` shows all leases with status
+
+The lease window (default 90 days) is intentionally much longer than the
+attestation TTL (6 hours). Attestations are the "session key" that rotates
+frequently; leases are the "access policy" that governs who can refresh.
+
+---
+
+### Decision 90: Production deployment — 3 Vultr VPS with Caddy
+
+**Context:** PoC needed live demo for stakeholder review.
+
+**Decision:** Three Vultr VPS (Ubuntu 26.04):
+- Hub: 209.250.238.223 (hub.arfl.us)
+- Entry: 64.176.43.74 (entry.arfl.us)
+- Exit: 155.138.136.155 (exit.arfl.us)
+
+Caddy v2 for auto HTTPS (Let's Encrypt) + reverse proxy. Systemd services
+for process management. DNS on OVH (arfl.us domain). Mainnet Lightning
+via Voltage LND (arfl-node.m.voltageapp.io:8080).
+
+---
+
+### Decision 91: Web client — static SPA at hub.arfl.us
+
+**Context:** Need a demo interface for non-technical stakeholders.
+
+**Decision:** Static single-page app (HTML/JS/CSS) served by Caddy from
+`/opt/arfl/web`. Uses Hub REST API directly. Features: tier selection,
+Lightning QR code generation, payment polling, token redemption, WireGuard
+config download. WebCrypto X25519 for client-side WG keypair generation.
+Repo: `Radi-Labs/arfl-client-web`.
+
+---
+
+### Decision 92: Bandwidth economics — residential-only viability
+
+**Context:** At $5/250GB, nodes earn ~$0.008/GB each. Cloud hosting bandwidth
+costs would eat profits.
+
+**Decision:** The model is strictly for residential and unmetered passive node
+runners, not commercial cloud servers. Operators earn from bandwidth they
+already own (flat-rate home fiber). Added caveat to whitepaper that cloud
+hosting is explicitly not viable. Bootstrap problem (low traffic = low earnings)
+acknowledged as a growth problem, not an economics problem.

--- a/cmd/arfl-hub/main.go
+++ b/cmd/arfl-hub/main.go
@@ -31,6 +31,15 @@ func main() {
 		case "attest":
 			runAttest(os.Args[2:])
 			return
+		case "revoke":
+			runRevoke(os.Args[2:])
+			return
+		case "renew":
+			runRenew(os.Args[2:])
+			return
+		case "list-nodes":
+			runListNodes(os.Args[2:])
+			return
 		}
 	}
 
@@ -208,7 +217,7 @@ func main() {
 
 	// Discovery endpoints.
 	discoveryAPI := discovery.NewDiscoveryAPI(idx)
-	discoveryAPI.SetHubKeyPair(hubKP)
+	discoveryAPI.SetHubKeyPair(hubKP, db)
 	mux.Handle("/nodes", discoveryAPI.Handler())
 	mux.Handle("/health", discoveryAPI.Handler())
 	mux.Handle("/attest/", discoveryAPI.Handler())
@@ -349,7 +358,7 @@ func loadOrGenerateDenomKey(keyDir, keyID string, bytesPerToken int64) (*credent
 }
 
 // runAttest generates a signed attestation for a node.
-// Usage: arfl-hub attest --config hub.json --node-pubkey <hex> --node-wg-key <base64> --operator <id> --role <entry|exit>
+// Usage: arfl-hub attest --config hub.json --node-pubkey <hex> --node-wg-key <base64> --operator <id> --role <entry|exit> [--lease 90d]
 func runAttest(args []string) {
 	fs := flag.NewFlagSet("attest", flag.ExitOnError)
 	cfgPath := fs.String("config", "hub.json", "path to hub config file")
@@ -358,6 +367,7 @@ func runAttest(args []string) {
 	operator := fs.String("operator", "", "operator identifier")
 	role := fs.String("role", "", "allowed role: entry, exit, or both")
 	outFile := fs.String("out", "", "write attestation to file (default: stdout)")
+	leaseDur := fs.String("lease", "", "lease duration (e.g. 90d, 30d, 7d). Stores in DB and enforces on refresh")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: arfl-hub attest [flags]\n\n")
 		fmt.Fprintf(os.Stderr, "Generate a signed attestation for a node. The hub vouches that this\n")
@@ -367,7 +377,7 @@ func runAttest(args []string) {
 		fmt.Fprintf(os.Stderr, "    --node-pubkey abc123...def \\\n")
 		fmt.Fprintf(os.Stderr, "    --node-wg-key YWJjZGVm... \\\n")
 		fmt.Fprintf(os.Stderr, "    --operator my-org \\\n")
-		fmt.Fprintf(os.Stderr, "    --role entry\n\n")
+		fmt.Fprintf(os.Stderr, "    --role entry --lease 90d\n\n")
 		fmt.Fprintf(os.Stderr, "Flags:\n")
 		fs.PrintDefaults()
 	}
@@ -414,9 +424,40 @@ func runAttest(args []string) {
 		os.Exit(1)
 	}
 
-	encoded, err := att.Encode()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: encode attestation: %v\n", err)
+	// If lease specified, store in database.
+	if *leaseDur != "" {
+		dur, parseErr := parseDuration(*leaseDur)
+		if parseErr != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid --lease: %v\n", parseErr)
+			os.Exit(1)
+		}
+
+		dbPath := filepath.Join(filepath.Dir(*cfgPath), "arfl-hub.db")
+		db, dbErr := store.Open(dbPath)
+		if dbErr != nil {
+			fmt.Fprintf(os.Stderr, "Error: open database: %v\n", dbErr)
+			os.Exit(1)
+		}
+		defer db.Close()
+
+		lease := store.NodeLease{
+			NodePubkey:   *nodePubkey,
+			NodeWGPubkey: *nodeWGKey,
+			OperatorID:   *operator,
+			AllowedRoles: roles,
+			LeaseStart:   time.Now().UTC(),
+			LeaseEnd:     time.Now().UTC().Add(dur),
+		}
+		if err := db.UpsertNodeLease(lease); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: store lease: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Lease stored: expires %s\n", lease.LeaseEnd.Format(time.RFC3339))
+	}
+
+	encoded, encErr := att.Encode()
+	if encErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: encode attestation: %v\n", encErr)
 		os.Exit(1)
 	}
 
@@ -432,5 +473,157 @@ func runAttest(args []string) {
 		fmt.Fprintf(os.Stderr, "Expires:     %d (%s)\n", att.ExpiresAt, time.Unix(att.ExpiresAt, 0).Format(time.RFC3339))
 	} else {
 		fmt.Println(encoded)
+	}
+}
+
+// runRevoke immediately revokes a node's lease.
+func runRevoke(args []string) {
+	fs := flag.NewFlagSet("revoke", flag.ExitOnError)
+	cfgPath := fs.String("config", "hub.json", "path to hub config file")
+	nodePubkey := fs.String("node-pubkey", "", "node's Nostr public key (64-char hex)")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: arfl-hub revoke --node-pubkey <hex> [--config hub.json]\n\n")
+		fmt.Fprintf(os.Stderr, "Immediately revoke a node's lease. The node will be unable to\n")
+		fmt.Fprintf(os.Stderr, "refresh its attestation and will drop off the network.\n\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+	if *nodePubkey == "" {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	dbPath := filepath.Join(filepath.Dir(*cfgPath), "arfl-hub.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: open database: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	if err := db.RevokeNodeLease(*nodePubkey); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "Node %s revoked successfully\n", *nodePubkey)
+}
+
+// runRenew extends a node's lease.
+func runRenew(args []string) {
+	fs := flag.NewFlagSet("renew", flag.ExitOnError)
+	cfgPath := fs.String("config", "hub.json", "path to hub config file")
+	nodePubkey := fs.String("node-pubkey", "", "node's Nostr public key (64-char hex)")
+	leaseDur := fs.String("lease", "", "new lease duration from now (e.g. 90d, 30d)")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: arfl-hub renew --node-pubkey <hex> --lease 90d [--config hub.json]\n\n")
+		fmt.Fprintf(os.Stderr, "Extend a node's lease. Clears any revocation.\n\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+	if *nodePubkey == "" || *leaseDur == "" {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	dur, err := parseDuration(*leaseDur)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: invalid --lease: %v\n", err)
+		os.Exit(1)
+	}
+
+	dbPath := filepath.Join(filepath.Dir(*cfgPath), "arfl-hub.db")
+	db, dbErr := store.Open(dbPath)
+	if dbErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: open database: %v\n", dbErr)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	newEnd := time.Now().UTC().Add(dur)
+	if err := db.RenewNodeLease(*nodePubkey, newEnd); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "Node %s renewed until %s\n", *nodePubkey, newEnd.Format(time.RFC3339))
+}
+
+// runListNodes shows all node leases.
+func runListNodes(args []string) {
+	fs := flag.NewFlagSet("list-nodes", flag.ExitOnError)
+	cfgPath := fs.String("config", "hub.json", "path to hub config file")
+	fs.Parse(args)
+
+	dbPath := filepath.Join(filepath.Dir(*cfgPath), "arfl-hub.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: open database: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	leases, err := db.ListNodeLeases()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(leases) == 0 {
+		fmt.Println("No node leases found.")
+		return
+	}
+
+	now := time.Now()
+	fmt.Printf("%-18s %-10s %-12s %-8s %-25s %s\n",
+		"NODE (first 16)", "OPERATOR", "ROLES", "STATUS", "EXPIRES", "WG KEY")
+	fmt.Println("-------------------------------------------------------------------------------------------------------------------")
+	for _, l := range leases {
+		status := "ACTIVE"
+		if l.Revoked {
+			status = "REVOKED"
+		} else if now.After(l.LeaseEnd) {
+			status = "EXPIRED"
+		}
+		rolesStr := fmt.Sprintf("%v", l.AllowedRoles)
+		pubShort := l.NodePubkey
+		if len(pubShort) > 16 {
+			pubShort = pubShort[:16] + ".."
+		}
+		wgShort := l.NodeWGPubkey
+		if len(wgShort) > 20 {
+			wgShort = wgShort[:20] + ".."
+		}
+		fmt.Printf("%-18s %-10s %-12s %-8s %-25s %s\n",
+			pubShort, l.OperatorID, rolesStr, status,
+			l.LeaseEnd.Format("2006-01-02 15:04 UTC"), wgShort)
+	}
+}
+
+// parseDuration parses human-friendly durations like "90d", "30d", "7d", "24h".
+func parseDuration(s string) (time.Duration, error) {
+	if len(s) < 2 {
+		return 0, fmt.Errorf("too short: %q", s)
+	}
+	unit := s[len(s)-1]
+	numStr := s[:len(s)-1]
+	var n int
+	if _, err := fmt.Sscanf(numStr, "%d", &n); err != nil {
+		return 0, fmt.Errorf("invalid number in %q: %w", s, err)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("duration must be positive: %q", s)
+	}
+	switch unit {
+	case 'd':
+		return time.Duration(n) * 24 * time.Hour, nil
+	case 'h':
+		return time.Duration(n) * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("unknown unit %q in %q (use d or h)", string(unit), s)
 	}
 }

--- a/cmd/arfl-hub/main.go
+++ b/cmd/arfl-hub/main.go
@@ -208,8 +208,10 @@ func main() {
 
 	// Discovery endpoints.
 	discoveryAPI := discovery.NewDiscoveryAPI(idx)
+	discoveryAPI.SetHubKeyPair(hubKP)
 	mux.Handle("/nodes", discoveryAPI.Handler())
 	mux.Handle("/health", discoveryAPI.Handler())
+	mux.Handle("/attest/", discoveryAPI.Handler())
 
 	// Payment endpoints.
 	mux.Handle("/purchase", purchaseAPI.Handler())

--- a/cmd/arfl-node/main.go
+++ b/cmd/arfl-node/main.go
@@ -214,6 +214,9 @@ func main() {
 			}
 
 			announcer := discovery.NewAnnouncer(nodeKP, nodeInfoFn, att, pool)
+			if cfg.HubURL != "" {
+				announcer.SetHubURL(cfg.HubURL)
+			}
 			go announcer.Run(ctx)
 			defer pool.Close()
 			log.Printf("[node] announcing to %d relay(s)", len(cfg.Relays))

--- a/internal/discovery/announcer.go
+++ b/internal/discovery/announcer.go
@@ -1,10 +1,13 @@
 package discovery
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/Radi-Labs/ARFL/internal/nostr"
@@ -25,6 +28,7 @@ type Announcer struct {
 	attestation *nostr.Attestation
 	pool        *nostr.RelayPool
 	interval    time.Duration
+	hubURL      string // Hub API URL for attestation refresh
 }
 
 // NewAnnouncer creates an announcer with the given identity and relay pool.
@@ -41,12 +45,20 @@ func NewAnnouncer(nodeKP *nostr.KeyPair, nodeInfoFn func() types.NodeInfo, att *
 	}
 }
 
+// SetHubURL enables automatic attestation refresh from the hub.
+// When set, the announcer will request a fresh attestation before the
+// current one expires.
+func (a *Announcer) SetHubURL(hubURL string) {
+	a.hubURL = hubURL
+}
+
 // Run starts the announcement loop. It blocks until ctx is cancelled.
 // Call this in a goroutine: go announcer.Run(ctx)
 func (a *Announcer) Run(ctx context.Context) {
 	log.Println("[announcer] starting announcement loop")
 
 	// Announce immediately on startup, then on ticker.
+	a.refreshIfNeeded(ctx)
 	if err := a.announce(ctx); err != nil {
 		log.Printf("[announcer] initial announcement failed: %v", err)
 	}
@@ -60,11 +72,37 @@ func (a *Announcer) Run(ctx context.Context) {
 			log.Println("[announcer] shutting down")
 			return
 		case <-ticker.C:
+			a.refreshIfNeeded(ctx)
 			if err := a.announce(ctx); err != nil {
 				log.Printf("[announcer] announcement failed: %v", err)
 			}
 		}
 	}
+}
+
+// refreshIfNeeded checks if the attestation is within 1 hour of expiry
+// and requests a fresh one from the hub.
+func (a *Announcer) refreshIfNeeded(ctx context.Context) {
+	if a.attestation == nil || a.hubURL == "" {
+		return
+	}
+
+	remaining := time.Until(time.Unix(a.attestation.ExpiresAt, 0))
+	if remaining > time.Hour {
+		return
+	}
+
+	log.Printf("[announcer] attestation expires in %s, refreshing...", remaining.Round(time.Second))
+
+	newAtt, err := a.refreshAttestation(ctx)
+	if err != nil {
+		log.Printf("[announcer] refresh failed: %v (will retry next tick)", err)
+		return
+	}
+
+	a.attestation = newAtt
+	log.Printf("[announcer] attestation refreshed, expires %s",
+		time.Unix(newAtt.ExpiresAt, 0).Format(time.RFC3339))
 }
 
 // announce creates and publishes a single node announcement event.
@@ -158,4 +196,73 @@ func BuildAnnouncementEvent(nodeKP *nostr.KeyPair, info types.NodeInfo, att *nos
 		return nil, fmt.Errorf("sign event: %w", err)
 	}
 	return event, nil
+}
+
+// AttestRefreshRequest is sent by a node to the hub to request a fresh attestation.
+type AttestRefreshRequest struct {
+	Attestation string `json:"attestation"` // Current (possibly near-expiry) attestation JSON
+	Timestamp   int64  `json:"timestamp"`   // Current unix timestamp
+	Signature   string `json:"signature"`   // Node's Schnorr signature over SHA256(attestation + timestamp)
+}
+
+// AttestRefreshResponse is returned by the hub with a fresh attestation.
+type AttestRefreshResponse struct {
+	Attestation string `json:"attestation"` // Fresh attestation JSON
+}
+
+// refreshAttestation calls the hub's /attest/refresh endpoint.
+// The node proves it owns the Nostr key by signing the request.
+func (a *Announcer) refreshAttestation(ctx context.Context) (*nostr.Attestation, error) {
+	attJSON, err := a.attestation.Encode()
+	if err != nil {
+		return nil, fmt.Errorf("encode current attestation: %w", err)
+	}
+
+	now := time.Now().Unix()
+
+	// Sign the refresh request with the node's Nostr key.
+	sig, err := nostr.SignRefreshRequest(a.nodeKP, attJSON, now)
+	if err != nil {
+		return nil, fmt.Errorf("sign refresh request: %w", err)
+	}
+
+	req := AttestRefreshRequest{
+		Attestation: attJSON,
+		Timestamp:   now,
+		Signature:   sig,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", a.hubURL+"/attest/refresh", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("hub request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("hub returned %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	var refreshResp AttestRefreshResponse
+	if err := json.NewDecoder(resp.Body).Decode(&refreshResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	newAtt, err := nostr.DecodeAttestation(refreshResp.Attestation)
+	if err != nil {
+		return nil, fmt.Errorf("decode new attestation: %w", err)
+	}
+
+	return newAtt, nil
 }

--- a/internal/discovery/api.go
+++ b/internal/discovery/api.go
@@ -22,6 +22,7 @@ import (
 type DiscoveryAPI struct {
 	index *NodeIndex
 	hubKP *nostr.KeyPair
+	store LeaseChecker
 	mux   *http.ServeMux
 
 	// Rate limiting: map[IP][]timestamp of recent requests.
@@ -29,6 +30,11 @@ type DiscoveryAPI struct {
 	rateMu      sync.Mutex
 	maxRequests int
 	rateWindow  time.Duration
+}
+
+// LeaseChecker is the interface needed to verify node leases.
+type LeaseChecker interface {
+	IsLeaseActive(nodePubkey string) (bool, error)
 }
 
 // DiscoveryResponse is what the client receives.
@@ -57,8 +63,9 @@ func NewDiscoveryAPI(index *NodeIndex) *DiscoveryAPI {
 }
 
 // SetHubKeyPair enables the /attest/refresh endpoint.
-func (api *DiscoveryAPI) SetHubKeyPair(kp *nostr.KeyPair) {
+func (api *DiscoveryAPI) SetHubKeyPair(kp *nostr.KeyPair, leaseStore LeaseChecker) {
 	api.hubKP = kp
+	api.store = leaseStore
 	api.mux.HandleFunc("/attest/refresh", api.handleAttestRefresh)
 }
 
@@ -195,6 +202,21 @@ func (api *DiscoveryAPI) handleAttestRefresh(w http.ResponseWriter, r *http.Requ
 	if err := nostr.VerifyRefreshRequest(att.NodePubkey, req.Attestation, req.Timestamp, req.Signature); err != nil {
 		http.Error(w, "invalid signature: "+err.Error(), http.StatusForbidden)
 		return
+	}
+
+	// Check if the node has an active lease.
+	if api.store != nil {
+		active, err := api.store.IsLeaseActive(att.NodePubkey)
+		if err != nil {
+			log.Printf("[attest-refresh] lease check error for %s: %v", att.NodePubkey[:16], err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if !active {
+			log.Printf("[attest-refresh] denied: node %s has no active lease", att.NodePubkey[:16]+"...")
+			http.Error(w, "lease expired or revoked", http.StatusForbidden)
+			return
+		}
 	}
 
 	// Issue a fresh attestation with the same parameters.

--- a/internal/discovery/api.go
+++ b/internal/discovery/api.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Radi-Labs/ARFL/internal/nostr"
 	"github.com/Radi-Labs/ARFL/pkg/types"
 )
 
@@ -20,6 +21,7 @@ import (
 // The hub CANNOT manipulate the list without being detected.
 type DiscoveryAPI struct {
 	index *NodeIndex
+	hubKP *nostr.KeyPair
 	mux   *http.ServeMux
 
 	// Rate limiting: map[IP][]timestamp of recent requests.
@@ -52,6 +54,12 @@ func NewDiscoveryAPI(index *NodeIndex) *DiscoveryAPI {
 	api.mux.HandleFunc("/health", api.handleHealth)
 
 	return api
+}
+
+// SetHubKeyPair enables the /attest/refresh endpoint.
+func (api *DiscoveryAPI) SetHubKeyPair(kp *nostr.KeyPair) {
+	api.hubKP = kp
+	api.mux.HandleFunc("/attest/refresh", api.handleAttestRefresh)
 }
 
 // Handler returns the HTTP handler for use with http.Server.
@@ -144,4 +152,80 @@ func (api *DiscoveryAPI) checkRateLimit(clientIP string) bool {
 
 	api.rateLimit[clientIP] = append(fresh, now)
 	return true
+}
+
+// handleAttestRefresh handles POST /attest/refresh.
+// A node presents its current attestation + a Schnorr signature proving
+// it owns the Nostr key. The hub verifies the signature, checks the
+// attestation was originally issued by itself, and returns a fresh one.
+func (api *DiscoveryAPI) handleAttestRefresh(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if api.hubKP == nil {
+		http.Error(w, "attestation refresh not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req AttestRefreshRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 8192)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Decode the current attestation.
+	att, err := nostr.DecodeAttestation(req.Attestation)
+	if err != nil {
+		http.Error(w, "invalid attestation: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// The attestation must have been issued by THIS hub.
+	if att.HubPubkey != api.hubKP.PubkeyHex() {
+		http.Error(w, "attestation not issued by this hub", http.StatusForbidden)
+		return
+	}
+
+	// Verify the attestation's own signature (proves it hasn't been tampered with).
+	// We allow expired attestations here — the whole point is to refresh them.
+	// But the signature and content hash must still be valid.
+	if att.Protocol != "arfl-node-attestation-v1" {
+		http.Error(w, "unknown attestation protocol", http.StatusBadRequest)
+		return
+	}
+	computedID, err := att.RecomputeID()
+	if err != nil || computedID != att.AttestationID {
+		http.Error(w, "attestation content hash mismatch", http.StatusBadRequest)
+		return
+	}
+
+	// Verify the node's signature on the refresh request.
+	if err := nostr.VerifyRefreshRequest(att.NodePubkey, req.Attestation, req.Timestamp, req.Signature); err != nil {
+		http.Error(w, "invalid signature: "+err.Error(), http.StatusForbidden)
+		return
+	}
+
+	// Issue a fresh attestation with the same parameters.
+	newAtt, err := nostr.CreateAttestation(api.hubKP, att.NodePubkey, att.NodeWGPubkey, att.OperatorID, att.AllowedRoles)
+	if err != nil {
+		log.Printf("[attest-refresh] create attestation error: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	encoded, err := newAtt.Encode()
+	if err != nil {
+		log.Printf("[attest-refresh] encode attestation error: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("[attest-refresh] refreshed attestation for node %s (role=%v, expires=%s)",
+		att.NodePubkey[:16]+"...", att.AllowedRoles, time.Unix(newAtt.ExpiresAt, 0).Format(time.RFC3339))
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(AttestRefreshResponse{Attestation: encoded})
 }

--- a/internal/discovery/api.go
+++ b/internal/discovery/api.go
@@ -184,21 +184,10 @@ func (api *DiscoveryAPI) handleAttestRefresh(w http.ResponseWriter, r *http.Requ
 	}
 
 	// The attestation must have been issued by THIS hub.
-	if att.HubPubkey != api.hubKP.PubkeyHex() {
-		http.Error(w, "attestation not issued by this hub", http.StatusForbidden)
-		return
-	}
-
-	// Verify the attestation's own signature (proves it hasn't been tampered with).
-	// We allow expired attestations here — the whole point is to refresh them.
-	// But the signature and content hash must still be valid.
-	if att.Protocol != "arfl-node-attestation-v1" {
-		http.Error(w, "unknown attestation protocol", http.StatusBadRequest)
-		return
-	}
-	computedID, err := att.RecomputeID()
-	if err != nil || computedID != att.AttestationID {
-		http.Error(w, "attestation content hash mismatch", http.StatusBadRequest)
+	// Verify the hub's Schnorr signature (proves it wasn't forged).
+	// We skip expiry check — the whole point is to refresh expired attestations.
+	if err := att.VerifySignature(api.hubKP.PubkeyHex()); err != nil {
+		http.Error(w, "attestation verification failed: "+err.Error(), http.StatusForbidden)
 		return
 	}
 

--- a/internal/nostr/attestation.go
+++ b/internal/nostr/attestation.go
@@ -71,6 +71,11 @@ func CreateAttestation(hubKP *KeyPair, nodePubkey, nodeWGPubkey, operatorID stri
 	return att, nil
 }
 
+// RecomputeID recomputes the attestation content hash for verification.
+func (a *Attestation) RecomputeID() (string, error) {
+	return a.computeID()
+}
+
 // computeID produces a deterministic hash of the attestation content.
 // This is what gets signed — change any field and the signature breaks.
 func (a *Attestation) computeID() (string, error) {
@@ -202,4 +207,57 @@ func DecodeAttestation(data string) (*Attestation, error) {
 		return nil, fmt.Errorf("decode attestation: %w", err)
 	}
 	return &att, nil
+}
+
+// SignRefreshRequest signs a refresh request with a node's private key.
+// The signature is over SHA256(attestationJSON || timestamp).
+func SignRefreshRequest(nodeKP *KeyPair, attJSON string, timestamp int64) (string, error) {
+	msg := fmt.Sprintf("%s%d", attJSON, timestamp)
+	hash := sha256.Sum256([]byte(msg))
+	sig, err := schnorr.Sign(nodeKP.PrivateKey, hash[:])
+	if err != nil {
+		return "", fmt.Errorf("sign refresh request: %w", err)
+	}
+	return hex.EncodeToString(sig.Serialize()), nil
+}
+
+// VerifyRefreshRequest verifies a node's signature on a refresh request.
+func VerifyRefreshRequest(nodePubkeyHex, attJSON string, timestamp int64, signatureHex string) error {
+	// Reject if timestamp is too old (5-minute window to prevent replay).
+	if abs(time.Now().Unix()-timestamp) > 300 {
+		return fmt.Errorf("timestamp too far from current time")
+	}
+
+	msg := fmt.Sprintf("%s%d", attJSON, timestamp)
+	hash := sha256.Sum256([]byte(msg))
+
+	pubBytes, err := hex.DecodeString(nodePubkeyHex)
+	if err != nil {
+		return fmt.Errorf("decode node pubkey: %w", err)
+	}
+	pubKey, err := schnorr.ParsePubKey(pubBytes)
+	if err != nil {
+		return fmt.Errorf("parse node pubkey: %w", err)
+	}
+
+	sigBytes, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+	sig, err := schnorr.ParseSignature(sigBytes)
+	if err != nil {
+		return fmt.Errorf("parse signature: %w", err)
+	}
+
+	if !sig.Verify(hash[:], pubKey) {
+		return fmt.Errorf("invalid signature")
+	}
+	return nil
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }

--- a/internal/nostr/attestation.go
+++ b/internal/nostr/attestation.go
@@ -98,6 +98,56 @@ func (a *Attestation) computeID() (string, error) {
 	return hex.EncodeToString(hash[:]), nil
 }
 
+// VerifySignature checks that the attestation was signed by the given hub key,
+// without checking expiry. Used by the refresh endpoint to validate attestations
+// that are near or past expiry before re-issuing.
+func (a *Attestation) VerifySignature(hubPubkeyHex string) error {
+	if a.Protocol != "arfl-node-attestation-v1" {
+		return fmt.Errorf("unknown attestation protocol: %s", a.Protocol)
+	}
+
+	if a.HubPubkey != hubPubkeyHex {
+		return fmt.Errorf("hub pubkey mismatch: got %s, expected %s", a.HubPubkey, hubPubkeyHex)
+	}
+
+	computedID, err := a.computeID()
+	if err != nil {
+		return fmt.Errorf("recompute attestation ID: %w", err)
+	}
+	if computedID != a.AttestationID {
+		return fmt.Errorf("attestation ID mismatch: computed %s, got %s", computedID, a.AttestationID)
+	}
+
+	pubBytes, err := hex.DecodeString(a.HubPubkey)
+	if err != nil {
+		return fmt.Errorf("decode hub pubkey: %w", err)
+	}
+	pubKey, err := schnorr.ParsePubKey(pubBytes)
+	if err != nil {
+		return fmt.Errorf("parse hub pubkey: %w", err)
+	}
+
+	sigBytes, err := hex.DecodeString(a.Signature)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+	sig, err := schnorr.ParseSignature(sigBytes)
+	if err != nil {
+		return fmt.Errorf("parse signature: %w", err)
+	}
+
+	idBytes, err := hex.DecodeString(a.AttestationID)
+	if err != nil {
+		return fmt.Errorf("decode attestation ID: %w", err)
+	}
+
+	if !sig.Verify(idBytes, pubKey) {
+		return fmt.Errorf("invalid attestation signature")
+	}
+
+	return nil
+}
+
 // Verify checks that an attestation is valid:
 //  1. Protocol version is correct
 //  2. Not expired

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Radi-Labs/ARFL/internal/credentials"
@@ -734,4 +735,141 @@ FROM redemptions WHERE nonce = ?`, nonce)
 		return nil, err
 	}
 	return &r, nil
+}
+
+// --- Node Lease operations ---
+
+// NodeLease represents an authorization window for a node.
+type NodeLease struct {
+	NodePubkey   string
+	NodeWGPubkey string
+	OperatorID   string
+	AllowedRoles []string
+	LeaseStart   time.Time
+	LeaseEnd     time.Time
+	Revoked      bool
+}
+
+// UpsertNodeLease creates or updates a node lease.
+func (s *Store) UpsertNodeLease(lease NodeLease) error {
+	roles := strings.Join(lease.AllowedRoles, ",")
+	_, err := s.db.Exec(`
+		INSERT INTO node_leases (node_pubkey, node_wg_pubkey, operator_id, allowed_roles, lease_start, lease_end, revoked)
+		VALUES (?, ?, ?, ?, ?, ?, 0)
+		ON CONFLICT(node_pubkey) DO UPDATE SET
+			node_wg_pubkey = excluded.node_wg_pubkey,
+			operator_id = excluded.operator_id,
+			allowed_roles = excluded.allowed_roles,
+			lease_start = excluded.lease_start,
+			lease_end = excluded.lease_end,
+			revoked = 0,
+			updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`,
+		lease.NodePubkey, lease.NodeWGPubkey, lease.OperatorID, roles,
+		lease.LeaseStart.UTC().Format(time.RFC3339),
+		lease.LeaseEnd.UTC().Format(time.RFC3339),
+	)
+	return err
+}
+
+// GetNodeLease retrieves a node's lease. Returns nil if not found.
+func (s *Store) GetNodeLease(nodePubkey string) (*NodeLease, error) {
+	var l NodeLease
+	var roles string
+	var start, end string
+	var revoked int
+	err := s.db.QueryRow(`
+		SELECT node_pubkey, node_wg_pubkey, operator_id, allowed_roles,
+		       lease_start, lease_end, revoked
+		FROM node_leases WHERE node_pubkey = ?`, nodePubkey).Scan(
+		&l.NodePubkey, &l.NodeWGPubkey, &l.OperatorID, &roles,
+		&start, &end, &revoked,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	l.AllowedRoles = strings.Split(roles, ",")
+	l.LeaseStart, _ = time.Parse(time.RFC3339, start)
+	l.LeaseEnd, _ = time.Parse(time.RFC3339, end)
+	l.Revoked = revoked != 0
+	return &l, nil
+}
+
+// IsLeaseActive checks if a node has a valid, non-revoked, non-expired lease.
+func (s *Store) IsLeaseActive(nodePubkey string) (bool, error) {
+	lease, err := s.GetNodeLease(nodePubkey)
+	if err != nil {
+		return false, err
+	}
+	if lease == nil {
+		return false, nil
+	}
+	if lease.Revoked {
+		return false, nil
+	}
+	return time.Now().Before(lease.LeaseEnd), nil
+}
+
+// RevokeNodeLease immediately revokes a node's lease.
+func (s *Store) RevokeNodeLease(nodePubkey string) error {
+	res, err := s.db.Exec(`
+		UPDATE node_leases SET revoked = 1,
+		updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+		WHERE node_pubkey = ?`, nodePubkey)
+	if err != nil {
+		return err
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("no lease found for node %s", nodePubkey)
+	}
+	return nil
+}
+
+// RenewNodeLease extends a node's lease end time. Clears revocation.
+func (s *Store) RenewNodeLease(nodePubkey string, newEnd time.Time) error {
+	res, err := s.db.Exec(`
+		UPDATE node_leases SET lease_end = ?, revoked = 0,
+		updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+		WHERE node_pubkey = ?`,
+		newEnd.UTC().Format(time.RFC3339), nodePubkey)
+	if err != nil {
+		return err
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("no lease found for node %s", nodePubkey)
+	}
+	return nil
+}
+
+// ListNodeLeases returns all node leases.
+func (s *Store) ListNodeLeases() ([]NodeLease, error) {
+	rows, err := s.db.Query(`
+		SELECT node_pubkey, node_wg_pubkey, operator_id, allowed_roles,
+		       lease_start, lease_end, revoked
+		FROM node_leases ORDER BY lease_end DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var leases []NodeLease
+	for rows.Next() {
+		var l NodeLease
+		var roles, start, end string
+		var revoked int
+		if err := rows.Scan(&l.NodePubkey, &l.NodeWGPubkey, &l.OperatorID,
+			&roles, &start, &end, &revoked); err != nil {
+			return nil, err
+		}
+		l.AllowedRoles = strings.Split(roles, ",")
+		l.LeaseStart, _ = time.Parse(time.RFC3339, start)
+		l.LeaseEnd, _ = time.Parse(time.RFC3339, end)
+		l.Revoked = revoked != 0
+		leases = append(leases, l)
+	}
+	return leases, nil
 }

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -327,4 +327,20 @@ BEFORE UPDATE ON redemptions
 BEGIN
     SELECT RAISE(FAIL, 'redemptions is append-only: updates are prohibited');
 END;
+
+-- ============================================================
+-- NODE LEASES: Authorization windows for node attestation refresh
+-- A node can only refresh its attestation while its lease is active.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS node_leases (
+    node_pubkey     TEXT PRIMARY KEY,
+    node_wg_pubkey  TEXT    NOT NULL,
+    operator_id     TEXT    NOT NULL,
+    allowed_roles   TEXT    NOT NULL,
+    lease_start     TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    lease_end       TEXT    NOT NULL,
+    revoked         INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
 `

--- a/internal/wg/manager.go
+++ b/internal/wg/manager.go
@@ -156,7 +156,15 @@ func (m *WgctrlManager) Close() error {
 func (m *WgctrlManager) createOSInterface(name string) error {
 	switch runtime.GOOS {
 	case "linux":
-		return run("ip", "link", "add", name, "type", "wireguard")
+		// If the interface already exists (e.g. crash recovery), remove it first.
+		if err := run("ip", "link", "add", name, "type", "wireguard"); err != nil {
+			if strings.Contains(err.Error(), "File exists") {
+				_ = run("ip", "link", "delete", name)
+				return run("ip", "link", "add", name, "type", "wireguard")
+			}
+			return err
+		}
+		return nil
 	case "darwin":
 		// macOS uses wireguard-go userspace implementation
 		return run("wireguard-go", name)


### PR DESCRIPTION
## Summary

Production deployment hardening and attestation lifecycle management.

### Changes

**Attestation System**
- `arfl-hub attest` CLI subcommand for generating signed node attestations
- Auto-refresh: nodes refresh their 6-hour attestation before expiry via `POST /attest/refresh`
- Security fix: refresh endpoint now verifies hub's BIP-340 Schnorr signature (prevents attestation forgery)

**Node Lease System**
- `node_leases` SQLite table tracks authorization windows per node
- CLI: `arfl-hub revoke`, `renew`, `list-nodes` subcommands
- `--lease 90d` flag on `attest` stores lease alongside attestation
- Refresh endpoint checks lease validity before re-issuing

**Deployment Hardening**
- WireGuard interface crash recovery (handles stale interface on restart)
- Step-by-step deployment guide (`docs/deployment-guide.md`)
- Demo script for full purchase→pay→settle→connect flow
- README updates for Phase 6 (LND, env vars, Docker testnet, 408 tests)

### Security
- CRITICAL fix: attestation refresh no longer accepts forged attestations
- Lease-based revocation closes the indefinite-refresh gap
- 6-hour TTL + 90-day lease = short blast radius + admin control
