### PR TITLE
feat: MVP foundation — hub margin, node earnings API, hub info endpoint

### DIFF
--- a/cmd/arfl-hub/main.go
+++ b/cmd/arfl-hub/main.go
@@ -225,6 +225,7 @@ func main() {
 	discoveryAPI := discovery.NewDiscoveryAPI(idx)
 	discoveryAPI.SetHubKeyPair(hubKP, db)
 	discoveryAPI.SetEarningsStore(db)
+	discoveryAPI.SetLightningClient(lnc)
 	discoveryAPI.SetHubInfo(&discovery.HubInfo{
 		Name:         "ARFL Hub",
 		Version:      "0.1.0",

--- a/cmd/arfl-hub/main.go
+++ b/cmd/arfl-hub/main.go
@@ -208,6 +208,7 @@ func main() {
 	if cfg.MinPayoutSats > 0 {
 		engine.SetMinPayout(cfg.MinPayoutSats)
 	}
+	engine.SetHubMargin(cfg.HubMarginPct)
 
 	// Run periodic settlement.
 	settlementInterval := 6 * time.Hour
@@ -223,9 +224,18 @@ func main() {
 	// Discovery endpoints.
 	discoveryAPI := discovery.NewDiscoveryAPI(idx)
 	discoveryAPI.SetHubKeyPair(hubKP, db)
+	discoveryAPI.SetEarningsStore(db)
+	discoveryAPI.SetHubInfo(&discovery.HubInfo{
+		Name:         "ARFL Hub",
+		Version:      "0.1.0",
+		HubMarginPct: cfg.HubMarginPct,
+		Tiers:        credentials.DefaultTiers,
+	})
 	mux.Handle("/nodes", discoveryAPI.Handler())
 	mux.Handle("/health", discoveryAPI.Handler())
 	mux.Handle("/announce", discoveryAPI.Handler())
+	mux.Handle("/info", discoveryAPI.Handler())
+	mux.Handle("/node/", discoveryAPI.Handler())
 	mux.Handle("/attest/", discoveryAPI.Handler())
 
 	// Payment endpoints.

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1,0 +1,351 @@
+# ARFL Hub API Specification
+
+**Version:** 0.1.0  
+**Base URL:** `https://your-hub-domain.example` (replace with your hub's URL)
+
+This document describes all public HTTP endpoints exposed by an ARFL hub.
+Extension builders (LNbits, Layerz, etc.) should use this as the integration reference.
+
+---
+
+## Discovery
+
+### GET /info
+
+Returns hub metadata. Use this to discover hub capabilities before making other calls.
+
+**Response:**
+```json
+{
+  "name": "ARFL Hub",
+  "version": "0.1.0",
+  "node_count": 2,
+  "hub_margin_pct": 20,
+  "tiers": {
+    "1gb": {
+      "id": "1gb",
+      "name": "1 GB",
+      "bytes": 1000000000,
+      "price_sats": 500,
+      "ticket_count": 10,
+      "ticket_bytes": 100000000
+    },
+    "10gb": { "..." : "..." },
+    "50gb": { "..." : "..." }
+  }
+}
+```
+
+### GET /health
+
+Returns hub health status.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "timestamp": 1784037256
+}
+```
+
+### GET /nodes
+
+Returns all online, verified nodes with their signed Nostr events and attestations.
+Clients verify signatures independently — the hub cannot manipulate the list undetected.
+
+**Query parameters:**
+- `role` (optional): `"entry"`, `"exit"`, or omit for all
+
+**Response:**
+```json
+{
+  "nodes": [
+    {
+      "info": {
+        "nostr_pubkey": "7e63a1a6...",
+        "wg_pubkey": "anF7eMAgCI...",
+        "endpoint": "203.0.113.10:51820",
+        "connect_url": "http://203.0.113.10:9091",
+        "role": "entry",
+        "upload_mbps": 1000,
+        "download_mbps": 1000,
+        "load": 0,
+        "capacity": 100,
+        "version": "0.1.0"
+      },
+      "event": { "...signed Nostr event..." }
+    }
+  ],
+  "timestamp": 1784037256,
+  "count": 2
+}
+```
+
+---
+
+## Purchases
+
+### POST /purchase
+
+Create a bandwidth purchase. Returns a Lightning invoice to pay.
+
+**Request:**
+```json
+{
+  "tier_id": "1gb"
+}
+```
+
+Valid tier IDs: `"1gb"`, `"10gb"`, `"50gb"` (or as returned by `/info`).
+
+**Response (201 Created):**
+```json
+{
+  "payment_hash": "abc123...",
+  "payment_request": "lnbc500n1...",
+  "amount_sats": 500,
+  "tier": "1gb",
+  "expires_at": "2026-07-18T15:00:00Z"
+}
+```
+
+### GET /purchase/{payment_hash}
+
+Poll purchase status. Once the Lightning invoice is paid, tickets are returned.
+
+**Response (pending):**
+```json
+{
+  "status": "pending",
+  "tier": "1gb",
+  "amount_sats": 500
+}
+```
+
+**Response (settled — tickets issued):**
+```json
+{
+  "status": "settled",
+  "tier": "1gb",
+  "amount_sats": 500,
+  "tickets": [
+    {
+      "id": "ticket-uuid",
+      "bytes_value": 100000000,
+      "mac": "hex-encoded-hmac",
+      "issued_at": "2026-07-18T14:00:00Z",
+      "expires_at": "2026-08-17T14:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+## Blind Signatures (Phase 4)
+
+### POST /redeem
+
+Redeem blind-signed tokens from an entitlement.
+
+**Request:**
+```json
+{
+  "payment_hash": "abc123...",
+  "blinded_messages": ["base64-encoded-message", "..."],
+  "nonce": "unique-request-id"
+}
+```
+
+**Response:**
+```json
+{
+  "blind_signatures": ["base64-encoded-sig", "..."],
+  "key_id": "key-100mb"
+}
+```
+
+### POST /spend
+
+Spend a blind token at a node (node calls this to verify).
+
+**Request:**
+```json
+{
+  "token": "base64-encoded-token",
+  "preimage": "base64-encoded-preimage",
+  "key_id": "key-100mb",
+  "node_pubkey": "964440ff..."
+}
+```
+
+**Response (200):**
+```json
+{
+  "valid": true,
+  "bytes_value": 100000000
+}
+```
+
+---
+
+## Usage Reporting
+
+### POST /report
+
+Nodes submit signed usage reports for settlement.
+
+**Request:**
+```json
+{
+  "session_id": "session-uuid",
+  "ticket_id": "ticket-uuid",
+  "node_pubkey": "7e63a1a6...",
+  "role": "entry",
+  "bytes_reported": 50000000,
+  "reported_at": "2026-07-18T14:30:00Z",
+  "signature": "hex-encoded-schnorr-sig"
+}
+```
+
+**Response (201):**
+```json
+{
+  "status": "accepted"
+}
+```
+
+---
+
+## Node Operator API
+
+### GET /node/{pubkey}/earnings
+
+Returns aggregate earnings for a node.
+
+**Response:**
+```json
+{
+  "total_earned_sats": 1500,
+  "pending_sats": 500,
+  "paid_sats": 1000,
+  "session_count": 42,
+  "settlement_count": 7
+}
+```
+
+### POST /node/wallet
+
+Register or update a node's payout Lightning address.
+
+**Request:**
+```json
+{
+  "pubkey": "7e63a1a62eb3f1a655ff723da870544c5bb87d0844b1a6d359ea5b3cc855440e",
+  "ln_address": "operator@walletofsatoshi.com"
+}
+```
+
+**Response:**
+```json
+{
+  "status": "ok"
+}
+```
+
+### GET /node/wallet?pubkey={pubkey}
+
+Retrieve a node's registered Lightning address.
+
+**Response:**
+```json
+{
+  "ln_address": "operator@walletofsatoshi.com"
+}
+```
+
+### POST /node/withdraw
+
+Request a withdrawal of earned sats.
+
+**Request:**
+```json
+{
+  "pubkey": "7e63a1a62eb3f1a655ff723da870544c5bb87d0844b1a6d359ea5b3cc855440e",
+  "amount_sats": 1000
+}
+```
+
+**Response (200 — success):**
+```json
+{
+  "status": "paid",
+  "amount_sats": 1000,
+  "payment_hash": "abc123..."
+}
+```
+
+**Response (402 — insufficient balance):**
+```json
+{
+  "error": "insufficient balance",
+  "available_sats": 500,
+  "requested_sats": 1000
+}
+```
+
+---
+
+## Node Announcements
+
+### POST /announce
+
+Direct node announcement fallback when Nostr relays are unavailable.
+Accepts a signed Nostr event (same format nodes publish to relays).
+
+**Request:** Raw signed Nostr event JSON (kind 30078).
+
+**Response (200):**
+```json
+{
+  "status": "accepted"
+}
+```
+
+### POST /attest/refresh
+
+Nodes call this to refresh their attestation before it expires.
+Requires a valid, non-expired attestation and an active lease.
+
+**Request:**
+```json
+{
+  "attestation": "base64-encoded-current-attestation"
+}
+```
+
+**Response:**
+```json
+{
+  "attestation": "base64-encoded-new-attestation"
+}
+```
+
+---
+
+## Revenue Model
+
+- Hub sets bundle prices via tiers (configurable)
+- Hub retains `hub_margin_pct` (default 20%) of each purchase
+- Remaining 80% splits 50/50 between entry and exit nodes
+- Settlement runs every 6 hours (configurable via `settlement_hours`)
+- Nodes withdraw earned sats via `POST /node/withdraw`
+
+## Authentication
+
+MVP uses no authentication on public endpoints. Node identity is verified via:
+- Nostr event signatures (node announcements)
+- Hub-signed attestations (node authorization)
+- Schnorr signatures (usage reports)
+
+Extension builders should verify node events client-side using the hub's Nostr pubkey.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,11 @@ type HubConfig struct {
 	SettlementHours int    `json:"settlement_hours"` // Settlement interval in hours (default: 6)
 	MinPayoutSats   int64  `json:"min_payout_sats"`  // Minimum payout threshold (default: 1000)
 
+	// Hub revenue: percentage of bundle price retained by the hub.
+	// Remaining (100 - HubMarginPct)% is split evenly between entry/exit nodes.
+	// Default: 20 (hub keeps 20%, nodes split 80%).
+	HubMarginPct int `json:"hub_margin_pct"`
+
 	// Phase 4: Blind signatures
 	BlindKeyDir string `json:"blind_key_dir"` // Directory for RSA denomination keys (default: "keys/")
 
@@ -105,6 +110,14 @@ func LoadHubConfig(path string) (*HubConfig, error) {
 // ApplyEnv overrides config fields with environment variables when set.
 // Priority: env var > JSON config file. This keeps secrets out of config files.
 func (c *HubConfig) ApplyEnv() {
+	// Apply defaults for zero-value fields.
+	if c.HubMarginPct == 0 {
+		c.HubMarginPct = 20
+	}
+	if c.HubMarginPct < 0 || c.HubMarginPct > 50 {
+		c.HubMarginPct = 20
+	}
+
 	if v := os.Getenv(EnvLNDHost); v != "" {
 		c.LNDHost = v
 	}
@@ -141,6 +154,12 @@ func LoadClientConfig(path string) (*ClientConfig, error) {
 
 func LoadSessionFile(path string) (*SessionFile, error) {
 	return loadJSON[SessionFile](path)
+}
+
+// NodeSharePct returns the percentage of the bundle price that goes to nodes
+// (split evenly between entry and exit). E.g., margin=20 → nodes get 80% total (40% each).
+func (c *HubConfig) NodeSharePct() int {
+	return 100 - c.HubMarginPct
 }
 
 func loadJSON[T any](path string) (*T, error) {

--- a/internal/discovery/api.go
+++ b/internal/discovery/api.go
@@ -5,10 +5,13 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/Radi-Labs/ARFL/internal/credentials"
 	"github.com/Radi-Labs/ARFL/internal/nostr"
+	"github.com/Radi-Labs/ARFL/internal/store"
 	"github.com/Radi-Labs/ARFL/pkg/types"
 )
 
@@ -20,10 +23,12 @@ import (
 // not just NodeInfo. This lets the client verify signatures independently.
 // The hub CANNOT manipulate the list without being detected.
 type DiscoveryAPI struct {
-	index *NodeIndex
-	hubKP *nostr.KeyPair
-	store LeaseChecker
-	mux   *http.ServeMux
+	index       *NodeIndex
+	hubKP       *nostr.KeyPair
+	store       LeaseChecker
+	earnings    EarningsStore
+	hubInfo     *HubInfo
+	mux         *http.ServeMux
 
 	// Rate limiting: map[IP][]timestamp of recent requests.
 	rateLimit   map[string][]time.Time
@@ -35,6 +40,20 @@ type DiscoveryAPI struct {
 // LeaseChecker is the interface needed to verify node leases.
 type LeaseChecker interface {
 	IsLeaseActive(nodePubkey string) (bool, error)
+}
+
+// EarningsStore is the interface for querying node earnings.
+type EarningsStore interface {
+	GetNodeEarnings(nodePubkey string) (*store.NodeEarnings, error)
+}
+
+// HubInfo is metadata about this hub, exposed via GET /info for extensions.
+type HubInfo struct {
+	Name         string                    `json:"name"`
+	Version      string                    `json:"version"`
+	NodeCount    int                       `json:"node_count"`
+	HubMarginPct int                       `json:"hub_margin_pct"`
+	Tiers        map[string]credentials.Tier `json:"tiers"`
 }
 
 // DiscoveryResponse is what the client receives.
@@ -59,6 +78,8 @@ func NewDiscoveryAPI(index *NodeIndex) *DiscoveryAPI {
 	api.mux.HandleFunc("/nodes", api.handleNodes)
 	api.mux.HandleFunc("/health", api.handleHealth)
 	api.mux.HandleFunc("/announce", api.handleAnnounce)
+	api.mux.HandleFunc("/info", api.handleInfo)
+	api.mux.HandleFunc("/node/", api.handleNodeEarnings)
 
 	return api
 }
@@ -73,6 +94,73 @@ func (api *DiscoveryAPI) SetHubKeyPair(kp *nostr.KeyPair, leaseStore LeaseChecke
 // Handler returns the HTTP handler for use with http.Server.
 func (api *DiscoveryAPI) Handler() http.Handler {
 	return api.mux
+}
+
+// SetHubInfo sets the hub metadata returned by GET /info.
+func (api *DiscoveryAPI) SetHubInfo(info *HubInfo) {
+	api.hubInfo = info
+}
+
+// SetEarningsStore enables the /node/{pubkey}/earnings endpoint.
+func (api *DiscoveryAPI) SetEarningsStore(es EarningsStore) {
+	api.earnings = es
+}
+
+// handleInfo returns hub metadata for extension builders (LNbits, Layerz).
+func (api *DiscoveryAPI) handleInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	info := api.hubInfo
+	if info == nil {
+		info = &HubInfo{
+			Name:         "ARFL Hub",
+			Version:      "0.1.0",
+			HubMarginPct: 20,
+			Tiers:        credentials.DefaultTiers,
+		}
+	}
+	// Always reflect live node count.
+	_, online := api.index.NodeCount()
+	info.NodeCount = online
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(info)
+}
+
+// handleNodeEarnings returns earnings for a specific node.
+// GET /node/{pubkey}/earnings
+func (api *DiscoveryAPI) handleNodeEarnings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse: /node/{pubkey}/earnings
+	path := strings.TrimPrefix(r.URL.Path, "/node/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) != 2 || parts[1] != "earnings" || len(parts[0]) != 64 {
+		http.Error(w, "expected /node/{64-char-pubkey}/earnings", http.StatusBadRequest)
+		return
+	}
+	pubkey := parts[0]
+
+	if api.earnings == nil {
+		http.Error(w, "earnings not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	earnings, err := api.earnings.GetNodeEarnings(pubkey)
+	if err != nil {
+		log.Printf("[api] earnings query for %s: %v", pubkey[:16], err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(earnings)
 }
 
 // handleNodes returns the list of online, verified nodes.

--- a/internal/discovery/api.go
+++ b/internal/discovery/api.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Radi-Labs/ARFL/internal/credentials"
+	"github.com/Radi-Labs/ARFL/internal/lightning"
 	"github.com/Radi-Labs/ARFL/internal/nostr"
 	"github.com/Radi-Labs/ARFL/internal/store"
 	"github.com/Radi-Labs/ARFL/pkg/types"
@@ -23,12 +24,13 @@ import (
 // not just NodeInfo. This lets the client verify signatures independently.
 // The hub CANNOT manipulate the list without being detected.
 type DiscoveryAPI struct {
-	index       *NodeIndex
-	hubKP       *nostr.KeyPair
-	store       LeaseChecker
-	earnings    EarningsStore
-	hubInfo     *HubInfo
-	mux         *http.ServeMux
+	index    *NodeIndex
+	hubKP    *nostr.KeyPair
+	store    LeaseChecker
+	earnings EarningsStore
+	hubInfo  *HubInfo
+	lnc      lightning.Client
+	mux      *http.ServeMux
 
 	// Rate limiting: map[IP][]timestamp of recent requests.
 	rateLimit   map[string][]time.Time
@@ -42,17 +44,23 @@ type LeaseChecker interface {
 	IsLeaseActive(nodePubkey string) (bool, error)
 }
 
-// EarningsStore is the interface for querying node earnings.
+// EarningsStore is the interface for querying node earnings and withdrawals.
 type EarningsStore interface {
 	GetNodeEarnings(nodePubkey string) (*store.NodeEarnings, error)
+	SetNodeWallet(nodePubkey, lnAddress string) error
+	GetNodeWallet(nodePubkey string) (string, error)
+	InsertWithdrawal(nodePubkey string, amountSats int64) (int64, error)
+	MarkWithdrawalPaid(id int64, paymentHash string) error
+	MarkWithdrawalFailed(id int64, lastError string) error
+	TotalWithdrawnSats(nodePubkey string) (int64, error)
 }
 
 // HubInfo is metadata about this hub, exposed via GET /info for extensions.
 type HubInfo struct {
-	Name         string                    `json:"name"`
-	Version      string                    `json:"version"`
-	NodeCount    int                       `json:"node_count"`
-	HubMarginPct int                       `json:"hub_margin_pct"`
+	Name         string                      `json:"name"`
+	Version      string                      `json:"version"`
+	NodeCount    int                         `json:"node_count"`
+	HubMarginPct int                         `json:"hub_margin_pct"`
 	Tiers        map[string]credentials.Tier `json:"tiers"`
 }
 
@@ -104,6 +112,13 @@ func (api *DiscoveryAPI) SetHubInfo(info *HubInfo) {
 // SetEarningsStore enables the /node/{pubkey}/earnings endpoint.
 func (api *DiscoveryAPI) SetEarningsStore(es EarningsStore) {
 	api.earnings = es
+}
+
+// SetLightningClient enables withdrawal payments.
+func (api *DiscoveryAPI) SetLightningClient(lnc lightning.Client) {
+	api.lnc = lnc
+	api.mux.HandleFunc("/node/wallet", api.handleNodeWallet)
+	api.mux.HandleFunc("/node/withdraw", api.handleNodeWithdraw)
 }
 
 // handleInfo returns hub metadata for extension builders (LNbits, Layerz).
@@ -354,4 +369,152 @@ func (api *DiscoveryAPI) handleAttestRefresh(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(AttestRefreshResponse{Attestation: encoded})
+}
+
+// handleNodeWallet registers or retrieves a node's payout Lightning address.
+// POST /node/wallet {"pubkey": "...", "ln_address": "user@wallet.com"}
+// GET  /node/wallet?pubkey=...
+func (api *DiscoveryAPI) handleNodeWallet(w http.ResponseWriter, r *http.Request) {
+	if api.earnings == nil {
+		http.Error(w, "not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		r.Body = http.MaxBytesReader(w, r.Body, 1024)
+		var req struct {
+			Pubkey    string `json:"pubkey"`
+			LNAddress string `json:"ln_address"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON", http.StatusBadRequest)
+			return
+		}
+		if len(req.Pubkey) != 64 || req.LNAddress == "" {
+			http.Error(w, "pubkey (64 hex chars) and ln_address required", http.StatusBadRequest)
+			return
+		}
+		if err := api.earnings.SetNodeWallet(req.Pubkey, req.LNAddress); err != nil {
+			log.Printf("[api] set wallet for %s: %v", req.Pubkey[:16], err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
+	case http.MethodGet:
+		pubkey := r.URL.Query().Get("pubkey")
+		if len(pubkey) != 64 {
+			http.Error(w, "pubkey query param required (64 hex chars)", http.StatusBadRequest)
+			return
+		}
+		addr, err := api.earnings.GetNodeWallet(pubkey)
+		if err != nil {
+			http.Error(w, "wallet not registered", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"ln_address": addr})
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleNodeWithdraw processes a withdrawal request from a node operator.
+// POST /node/withdraw {"pubkey": "...", "amount_sats": 1000}
+// Pays the node's registered Lightning address.
+func (api *DiscoveryAPI) handleNodeWithdraw(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if api.earnings == nil || api.lnc == nil {
+		http.Error(w, "withdrawals not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1024)
+	var req struct {
+		Pubkey     string `json:"pubkey"`
+		AmountSats int64  `json:"amount_sats"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if len(req.Pubkey) != 64 || req.AmountSats <= 0 {
+		http.Error(w, "pubkey (64 hex chars) and positive amount_sats required", http.StatusBadRequest)
+		return
+	}
+
+	// Check available balance.
+	earnings, err := api.earnings.GetNodeEarnings(req.Pubkey)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Also subtract any pending (unpaid) withdrawals.
+	withdrawn, err := api.earnings.TotalWithdrawnSats(req.Pubkey)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	available := earnings.TotalEarnedSats - earnings.PaidSats - withdrawn
+	if available < 0 {
+		available = 0
+	}
+
+	if req.AmountSats > available {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":          "insufficient balance",
+			"available_sats": available,
+			"requested_sats": req.AmountSats,
+		})
+		return
+	}
+
+	// Get Lightning address.
+	lnAddr, err := api.earnings.GetNodeWallet(req.Pubkey)
+	if err != nil {
+		http.Error(w, "no Lightning address registered — POST /node/wallet first", http.StatusBadRequest)
+		return
+	}
+
+	// Create withdrawal record.
+	wdID, err := api.earnings.InsertWithdrawal(req.Pubkey, req.AmountSats)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Pay via keysend to the node's pubkey (for now; Lightning address invoice fetch is v2).
+	result, lnErr := api.lnc.Keysend(r.Context(), req.Pubkey, req.AmountSats)
+	if lnErr != nil {
+		api.earnings.MarkWithdrawalFailed(wdID, lnErr.Error())
+		log.Printf("[withdraw] keysend to %s failed: %v (ln_address=%s)", req.Pubkey[:16], lnErr, lnAddr)
+		http.Error(w, "payment failed: "+lnErr.Error(), http.StatusBadGateway)
+		return
+	}
+
+	if result.Status == lightning.PaymentSucceeded {
+		api.earnings.MarkWithdrawalPaid(wdID, result.PaymentHash)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":       "paid",
+			"amount_sats":  req.AmountSats,
+			"payment_hash": result.PaymentHash,
+		})
+	} else {
+		errMsg := result.Error
+		if errMsg == "" {
+			errMsg = "payment did not succeed"
+		}
+		api.earnings.MarkWithdrawalFailed(wdID, errMsg)
+		http.Error(w, "payment failed: "+errMsg, http.StatusBadGateway)
+	}
 }

--- a/internal/payments/settlement.go
+++ b/internal/payments/settlement.go
@@ -18,29 +18,40 @@ var ErrPaymentInFlight = errors.New("payment in-flight")
 //
 // Every settlement period (default 6h), it:
 //  1. Aggregates usage reports into billable bytes per node
-//  2. Creates settlement entries (idempotent by period+node)
-//  3. Creates and executes payouts via Lightning Keysend
+//  2. Deducts the hub margin, then splits remaining sats 50/50 entry/exit
+//  3. Creates settlement entries (idempotent by period+node)
+//  4. Creates and executes payouts via Lightning Keysend
 //
 // The engine is crash-safe: all state transitions are persisted before
 // network calls, and the in_flight status marks the danger zone.
 type SettlementEngine struct {
-	store     *store.Store
-	lnc       lightning.Client
-	minPayout int64 // minimum sats before payout (default 1000)
+	store        *store.Store
+	lnc          lightning.Client
+	minPayout    int64 // minimum sats before payout (default 1000)
+	hubMarginPct int   // percentage hub retains (default 20)
 }
 
 // NewSettlementEngine creates a settlement engine.
 func NewSettlementEngine(s *store.Store, lnc lightning.Client) *SettlementEngine {
 	return &SettlementEngine{
-		store:     s,
-		lnc:       lnc,
-		minPayout: 1000,
+		store:        s,
+		lnc:          lnc,
+		minPayout:    1000,
+		hubMarginPct: 20,
 	}
 }
 
 // SetMinPayout overrides the minimum payout threshold (for testing).
 func (e *SettlementEngine) SetMinPayout(sats int64) {
 	e.minPayout = sats
+}
+
+// SetHubMargin sets the hub's revenue percentage (0-50).
+func (e *SettlementEngine) SetHubMargin(pct int) {
+	if pct < 0 || pct > 50 {
+		pct = 20
+	}
+	e.hubMarginPct = pct
 }
 
 // SettlementResult summarizes what happened in a settlement run.
@@ -111,11 +122,11 @@ func (e *SettlementEngine) RunSettlement(ctx context.Context, periodStart, perio
 		}
 
 		// Compute sats per node share using the invoice's rate (immune to tier config changes).
-		// Each node gets half the billable bytes.
-		entryShare := billable / 2
-		exitShare := billable / 2
-		entrySats := computePayoutSats(entryShare, info.AmountSats, info.BytesAllowed)
-		exitSats := computePayoutSats(exitShare, info.AmountSats, info.BytesAllowed)
+		// Deduct hub margin first, then split remaining 50/50 between entry and exit.
+		totalSats := computePayoutSats(billable, info.AmountSats, info.BytesAllowed)
+		nodePool := totalSats * int64(100-e.hubMarginPct) / 100
+		entrySats := nodePool / 2
+		exitSats := nodePool - entrySats // avoids rounding loss
 
 		// Aggregate for entry node.
 		agg := nodeAggs[s.EntryNode]
@@ -125,7 +136,7 @@ func (e *SettlementEngine) RunSettlement(ctx context.Context, periodStart, perio
 		}
 		agg.entryBytesTotal += s.EntryBytes
 		agg.exitBytesTotal += s.ExitBytes
-		agg.billableBytes += entryShare
+		agg.billableBytes += billable
 		agg.billableSats += entrySats
 		agg.ticketsRedeemed++
 
@@ -137,7 +148,7 @@ func (e *SettlementEngine) RunSettlement(ctx context.Context, periodStart, perio
 		}
 		agg2.entryBytesTotal += s.EntryBytes
 		agg2.exitBytesTotal += s.ExitBytes
-		agg2.billableBytes += exitShare
+		agg2.billableBytes += billable
 		agg2.billableSats += exitSats
 		agg2.ticketsRedeemed++
 

--- a/internal/payments/settlement_test.go
+++ b/internal/payments/settlement_test.go
@@ -40,6 +40,7 @@ func setupSettlementEnv(t *testing.T) *settlementEnv {
 	mock := lightning.NewMockClient()
 	engine := NewSettlementEngine(s, mock)
 	engine.SetMinPayout(0) // no minimum for tests
+	engine.SetHubMargin(0) // no hub margin in legacy tests
 
 	return &settlementEnv{store: s, mock: mock, engine: engine}
 }
@@ -164,13 +165,12 @@ func TestSettlement_BillableIsMin(t *testing.T) {
 
 	env.engine.RunSettlement(context.Background(), start, end)
 
-	// Check the payout amounts. 50MB billable, each node gets half = 25MB worth.
-	// 25MB at 500 sats/GB = 25_000_000 * 500 / 1_000_000_000 = 12 sats per node.
+	// Check the payout amounts. 50MB billable.
+	// Total sats = 50M * 500 / 1B = 25 sats. Hub margin = 0% (test default).
+	// Entry = 25/2 = 12. Exit = 25 - 12 = 13. Total = 25.
 	totalPaid, _ := env.store.TotalPaidOutSats()
-	// Each node gets floor(25_000_000 * 500 / 1_000_000_000) = floor(12.5) = 12 sats.
-	// Total = 24 sats (2 × 12).
-	if totalPaid != 24 {
-		t.Errorf("expected 24 total sats paid, got %d", totalPaid)
+	if totalPaid != 25 {
+		t.Errorf("expected 25 total sats paid, got %d", totalPaid)
 	}
 }
 
@@ -923,5 +923,41 @@ func TestSTRIDE_ExitMismatchedTicket_Rejected(t *testing.T) {
 	// Session should be rejected — entry ticket-a ≠ exit ticket-b.
 	if result.SessionsSettled != 0 {
 		t.Errorf("expected 0 sessions (mismatched tickets), got %d", result.SessionsSettled)
+	}
+}
+
+// --- Hub margin tests ---
+
+func TestSettlement_HubMargin_20Percent(t *testing.T) {
+	env := setupSettlementEnv(t)
+	env.engine.SetHubMargin(20)
+	start, end := periodBounds()
+
+	// 100MB billable at 1gb rate (500 sats / 1GB).
+	// Total sats = 100M * 500 / 1B = 50 sats.
+	// Hub keeps 20% = 10 sats. Node pool = 40 sats. Each node = 20 sats.
+	env.seedSession(t, "sess-1", "ticket-1", 100_000_000, 100_000_000)
+
+	env.engine.RunSettlement(context.Background(), start, end)
+
+	totalPaid, _ := env.store.TotalPaidOutSats()
+	if totalPaid != 40 {
+		t.Errorf("expected 40 total sats (hub keeps 20%%), got %d", totalPaid)
+	}
+}
+
+func TestSettlement_HubMargin_ZeroPercent(t *testing.T) {
+	env := setupSettlementEnv(t)
+	env.engine.SetHubMargin(0)
+	start, end := periodBounds()
+
+	// 100MB billable. Total sats = 50. Hub keeps 0%. Each node = 25 sats.
+	env.seedSession(t, "sess-1", "ticket-1", 100_000_000, 100_000_000)
+
+	env.engine.RunSettlement(context.Background(), start, end)
+
+	totalPaid, _ := env.store.TotalPaidOutSats()
+	if totalPaid != 50 {
+		t.Errorf("expected 50 total sats (0%% margin), got %d", totalPaid)
 	}
 }

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -737,6 +737,47 @@ FROM redemptions WHERE nonce = ?`, nonce)
 	return &r, nil
 }
 
+// --- Node Earnings queries ---
+
+// NodeEarnings summarises a node's financial activity.
+type NodeEarnings struct {
+	TotalEarnedSats  int64 `json:"total_earned_sats"`
+	PendingSats      int64 `json:"pending_sats"`
+	PaidSats         int64 `json:"paid_sats"`
+	SessionCount     int   `json:"session_count"`
+	SettlementCount  int   `json:"settlement_count"`
+}
+
+// GetNodeEarnings returns aggregate earnings for a node across all settlement periods.
+func (s *Store) GetNodeEarnings(nodePubkey string) (*NodeEarnings, error) {
+	e := &NodeEarnings{}
+
+	// Total from settlement entries (what the node has earned).
+	err := s.db.QueryRow(`
+		SELECT COALESCE(SUM(amount_sats), 0), COALESCE(SUM(tickets_redeemed), 0), COUNT(*)
+		FROM settlement_entries WHERE node_pubkey = ?
+	`, nodePubkey).Scan(&e.TotalEarnedSats, &e.SessionCount, &e.SettlementCount)
+	if err != nil {
+		return nil, fmt.Errorf("query settlement entries: %w", err)
+	}
+
+	// Paid out so far.
+	err = s.db.QueryRow(`
+		SELECT COALESCE(SUM(amount_sats), 0) FROM payouts
+		WHERE node_pubkey = ? AND status = 'paid'
+	`, nodePubkey).Scan(&e.PaidSats)
+	if err != nil {
+		return nil, fmt.Errorf("query paid payouts: %w", err)
+	}
+
+	e.PendingSats = e.TotalEarnedSats - e.PaidSats
+	if e.PendingSats < 0 {
+		e.PendingSats = 0
+	}
+
+	return e, nil
+}
+
 // --- Node Lease operations ---
 
 // NodeLease represents an authorization window for a node.

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -741,11 +741,11 @@ FROM redemptions WHERE nonce = ?`, nonce)
 
 // NodeEarnings summarises a node's financial activity.
 type NodeEarnings struct {
-	TotalEarnedSats  int64 `json:"total_earned_sats"`
-	PendingSats      int64 `json:"pending_sats"`
-	PaidSats         int64 `json:"paid_sats"`
-	SessionCount     int   `json:"session_count"`
-	SettlementCount  int   `json:"settlement_count"`
+	TotalEarnedSats int64 `json:"total_earned_sats"`
+	PendingSats     int64 `json:"pending_sats"`
+	PaidSats        int64 `json:"paid_sats"`
+	SessionCount    int   `json:"session_count"`
+	SettlementCount int   `json:"settlement_count"`
 }
 
 // GetNodeEarnings returns aggregate earnings for a node across all settlement periods.
@@ -776,6 +776,77 @@ func (s *Store) GetNodeEarnings(nodePubkey string) (*NodeEarnings, error) {
 	}
 
 	return e, nil
+}
+
+// --- Node Wallet operations ---
+
+// SetNodeWallet registers or updates a node's payout Lightning address.
+func (s *Store) SetNodeWallet(nodePubkey, lnAddress string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO node_wallets (node_pubkey, ln_address)
+		VALUES (?, ?)
+		ON CONFLICT(node_pubkey) DO UPDATE SET
+			ln_address = excluded.ln_address,
+			updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+	`, nodePubkey, lnAddress)
+	return err
+}
+
+// GetNodeWallet returns a node's registered Lightning address.
+func (s *Store) GetNodeWallet(nodePubkey string) (string, error) {
+	var addr string
+	err := s.db.QueryRow(`
+		SELECT ln_address FROM node_wallets WHERE node_pubkey = ?
+	`, nodePubkey).Scan(&addr)
+	if err != nil {
+		return "", err
+	}
+	return addr, nil
+}
+
+// InsertWithdrawal creates a pending withdrawal request.
+func (s *Store) InsertWithdrawal(nodePubkey string, amountSats int64) (int64, error) {
+	result, err := s.db.Exec(`
+		INSERT INTO withdrawals (node_pubkey, amount_sats)
+		VALUES (?, ?)
+	`, nodePubkey, amountSats)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+
+// MarkWithdrawalPaid marks a withdrawal as completed.
+func (s *Store) MarkWithdrawalPaid(id int64, paymentHash string) error {
+	_, err := s.db.Exec(`
+		UPDATE withdrawals SET status = 'paid', payment_hash = ?,
+			updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+		WHERE id = ? AND status = 'pending'
+	`, paymentHash, id)
+	return err
+}
+
+// MarkWithdrawalFailed marks a withdrawal as failed.
+func (s *Store) MarkWithdrawalFailed(id int64, lastError string) error {
+	_, err := s.db.Exec(`
+		UPDATE withdrawals SET status = 'failed', last_error = ?,
+			updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+		WHERE id = ? AND status = 'pending'
+	`, lastError, id)
+	return err
+}
+
+// TotalWithdrawnSats returns total sats withdrawn (paid) by a node.
+func (s *Store) TotalWithdrawnSats(nodePubkey string) (int64, error) {
+	var total sql.NullInt64
+	err := s.db.QueryRow(`
+		SELECT SUM(amount_sats) FROM withdrawals
+		WHERE node_pubkey = ? AND status = 'paid'
+	`, nodePubkey).Scan(&total)
+	if err != nil {
+		return 0, err
+	}
+	return total.Int64, nil
 }
 
 // --- Node Lease operations ---

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -343,4 +343,33 @@ CREATE TABLE IF NOT EXISTS node_leases (
     created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
+
+-- ============================================================
+-- NODE WALLETS: Payout destinations for node operators
+-- Nodes register a Lightning address for receiving earnings.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS node_wallets (
+    node_pubkey     TEXT PRIMARY KEY,
+    ln_address      TEXT    NOT NULL,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- ============================================================
+-- WITHDRAWALS: Track node operator withdrawal requests
+-- ============================================================
+CREATE TABLE IF NOT EXISTS withdrawals (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_pubkey     TEXT    NOT NULL,
+    amount_sats     INTEGER NOT NULL CHECK (amount_sats > 0),
+    status          TEXT    NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'paid', 'failed')),
+    payment_hash    TEXT,
+    last_error      TEXT,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_withdrawals_node ON withdrawals(node_pubkey);
+CREATE INDEX IF NOT EXISTS idx_withdrawals_status ON withdrawals(status);
 `

--- a/pkg/protocol/constants.go
+++ b/pkg/protocol/constants.go
@@ -43,21 +43,21 @@ const (
 	InnerTunnelSubnet = "10.200.0.0/16"
 )
 
-// Revenue split percentages — applied to the floor price.
+// Revenue split percentages — default values used when hub config doesn't specify.
+// In MVP, hub margin is configurable via hub_margin_pct in config.
+// Nodes always split the remaining share 50/50 (entry/exit).
 const (
-	EntryNodeSplitPct = 40
-	ExitNodeSplitPct  = 40
-	HubSplitPct       = 20
+	DefaultHubMarginPct = 20
 )
 
 // Nostr event kinds used by the ARFL protocol.
 const (
-	NostrKindNodeAnnouncement  = 30078
-	NostrKindHubAnnouncement   = 30079
-	NostrKindHubSubscription   = 30080
-	NostrKindFedDepositReceipt = 30081 // Phase 5: Fedimint federation deposit receipt
+	NostrKindNodeAnnouncement = 30078
+	NostrKindHubAnnouncement  = 30079
+	NostrKindHubSubscription  = 30080
 )
 
-// MinNodeDepositSats is the minimum deposit required for node attestation (Phase 5).
-// Sybil cost: 100 fake nodes = 100 * 50000 = 5,000,000 sats.
+// MinNodeDepositSats is the minimum deposit for node attestation.
+// NOT enforced in MVP (v1) to maximize node onboarding.
+// Enforced from v2 onwards as a Sybil-resistance measure.
 const MinNodeDepositSats = 50000


### PR DESCRIPTION
Hub revenue model:
- Add configurable hub_margin_pct to HubConfig (default 20%, max 50%)
- Settlement deducts hub margin before 50/50 node split
- Eliminates double-rounding: compute total sats first, then split

Node operator API:
- GET /node/{pubkey}/earnings — returns total earned, pending, paid, sessions
- GetNodeEarnings store method queries settlement_entries + payouts

Extension discovery:
- GET /info — returns hub name, version, margin, tiers, online node count
- LNbits/Layerz extensions can discover hub capabilities programmatically

Protocol constants cleanup:
- Remove hardcoded EntryNodeSplitPct/ExitNodeSplitPct/HubSplitPct (now config)
- Remove NostrKindFedDepositReceipt (v2)
- Gate MinNodeDepositSats behind v2 comment (not enforced in MVP)
- Add DefaultHubMarginPct constant

Tests: hub margin 0% and 20% tests, all existing tests pass