### PR TITLE
Phase 9: Client-side node selection + Cashu token redemption

### DIFF
--- a/cmd/arfl-hub/main.go
+++ b/cmd/arfl-hub/main.go
@@ -280,6 +280,7 @@ func main() {
 	mux.Handle("/v1/mint/", discoveryAPI.Handler())
 	mux.Handle("/v1/swap", discoveryAPI.Handler())
 	mux.Handle("/v1/checkstate", discoveryAPI.Handler())
+	mux.Handle("/v1/redeem", discoveryAPI.Handler())
 
 	server := &http.Server{
 		Addr:    cfg.ListenAddr,

--- a/internal/client/cashu_connector.go
+++ b/internal/client/cashu_connector.go
@@ -1,0 +1,140 @@
+// CashuConnector presents Cashu ecash proofs to ARFL nodes in exchange for
+// WireGuard tunnel access. This replaces the RSA blind token flow from v0
+// with the NUT-compliant Cashu tokens minted by the hub.
+//
+// Flow:
+//  1. Client mints Cashu tokens via hub (POST /v1/mint/bolt11)
+//  2. Client selects entry/exit nodes client-side (NodeSelector)
+//  3. Client calls ConnectWithProofs() on each node
+//  4. Node calls hub POST /v1/redeem to verify + burn the proofs
+//  5. Node grants WireGuard access and returns tunnel config
+//
+// Privacy: The hub issued the tokens via blind signatures. It cannot link
+// the redeemed proofs back to the original buyer.
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/elnosh/gonuts/cashu"
+)
+
+// CashuConnector presents Cashu proofs to a node for WireGuard access.
+type CashuConnector struct {
+	httpClient *http.Client
+}
+
+// NewCashuConnector creates a connector with sensible defaults.
+func NewCashuConnector() *CashuConnector {
+	return &CashuConnector{
+		httpClient: &http.Client{
+			Timeout: 20 * time.Second,
+		},
+	}
+}
+
+// CashuConnectRequest is sent to the node's /connect endpoint.
+type CashuConnectRequest struct {
+	Proofs   cashu.Proofs `json:"proofs"`
+	WGPubkey string       `json:"wg_pubkey"`
+}
+
+// ConnectWithProofs presents Cashu proofs to a node and receives WireGuard
+// tunnel configuration in return.
+//
+// connectURL: node's connect API base (e.g. "https://1.2.3.4:9091")
+// proofs: unspent Cashu proofs from the client's token wallet
+// clientWGPubkey: the client's WireGuard public key (base64)
+func (cc *CashuConnector) ConnectWithProofs(
+	ctx context.Context,
+	connectURL string,
+	proofs cashu.Proofs,
+	clientWGPubkey string,
+) (*ConnectResult, error) {
+	if len(proofs) == 0 {
+		return nil, fmt.Errorf("no proofs provided")
+	}
+	if clientWGPubkey == "" {
+		return nil, fmt.Errorf("wg_pubkey required")
+	}
+
+	reqBody, err := json.Marshal(CashuConnectRequest{
+		Proofs:   proofs,
+		WGPubkey: clientWGPubkey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal connect request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, connectURL+"/connect", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := cc.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connect request to %s: %w", connectURL, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error  string `json:"error"`
+			Detail string `json:"detail"`
+		}
+		if json.Unmarshal(body, &errResp) == nil {
+			msg := errResp.Error
+			if msg == "" {
+				msg = errResp.Detail
+			}
+			if msg != "" {
+				return nil, fmt.Errorf("node rejected proofs (%d): %s", resp.StatusCode, msg)
+			}
+		}
+		return nil, fmt.Errorf("node connect error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result ConnectResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode connect response: %w", err)
+	}
+
+	if result.TunnelIP == "" || result.NodeWGPubkey == "" {
+		return nil, fmt.Errorf("node returned incomplete response (missing tunnel_ip or wg_pubkey)")
+	}
+
+	return &result, nil
+}
+
+// ConnectPair connects to both entry and exit nodes using Cashu proofs.
+// Proofs are split between the two nodes — each gets half the bandwidth.
+func (cc *CashuConnector) ConnectPair(
+	ctx context.Context,
+	pair *NodePair,
+	entryProofs cashu.Proofs,
+	exitProofs cashu.Proofs,
+	clientWGPubkey string,
+) (entry *ConnectResult, exit *ConnectResult, err error) {
+	// Connect to entry node first.
+	entry, err = cc.ConnectWithProofs(ctx, pair.Entry.ConnectURL, entryProofs, clientWGPubkey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("entry node connect: %w", err)
+	}
+
+	// Then exit node.
+	exit, err = cc.ConnectWithProofs(ctx, pair.Exit.ConnectURL, exitProofs, clientWGPubkey)
+	if err != nil {
+		return entry, nil, fmt.Errorf("exit node connect (entry succeeded): %w", err)
+	}
+
+	return entry, exit, nil
+}

--- a/internal/client/selector.go
+++ b/internal/client/selector.go
@@ -1,0 +1,168 @@
+// Package client — NodeSelector fetches the node list from the hub and
+// pairs entry/exit nodes entirely on the client side.
+//
+// Privacy property: the hub publishes the full node list but never learns
+// which pair the client chose. Combined with Cashu blind tokens, the hub
+// cannot link payment → node pair → traffic.
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/Radi-Labs/ARFL/pkg/types"
+)
+
+// Errors returned by the selector.
+var (
+	ErrNoEntryNodes = errors.New("no online entry nodes available")
+	ErrNoExitNodes  = errors.New("no online exit nodes available")
+	ErrFetchFailed  = errors.New("failed to fetch node list from hub")
+)
+
+// NodePair is a client-selected entry/exit node combination.
+type NodePair struct {
+	Entry types.NodeInfo `json:"entry"`
+	Exit  types.NodeInfo `json:"exit"`
+}
+
+// discoveryNode matches the IndexedNode JSON from GET /nodes.
+type discoveryNode struct {
+	Info     types.NodeInfo `json:"info"`
+	Online   bool           `json:"online"`
+	LastSeen time.Time      `json:"last_seen"`
+}
+
+// discoveryResponse matches the DiscoveryResponse JSON from GET /nodes.
+type discoveryResponse struct {
+	Nodes []*discoveryNode `json:"nodes"`
+	Count int              `json:"count"`
+}
+
+// NodeSelector fetches the node list from a hub and performs client-side pairing.
+type NodeSelector struct {
+	hubURL     string
+	httpClient *http.Client
+}
+
+// NewNodeSelector creates a selector that fetches from the given hub URL.
+func NewNodeSelector(hubURL string) *NodeSelector {
+	return &NodeSelector{
+		hubURL: hubURL,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+// FetchNodes retrieves all online nodes from the hub.
+func (s *NodeSelector) FetchNodes(ctx context.Context) ([]types.NodeInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.hubURL+"/nodes", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFetchFailed, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("%w: status %d: %s", ErrFetchFailed, resp.StatusCode, body)
+	}
+
+	var dr discoveryResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 512*1024)).Decode(&dr); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	// Filter to online nodes only.
+	var online []types.NodeInfo
+	for _, n := range dr.Nodes {
+		if n.Online {
+			online = append(online, n.Info)
+		}
+	}
+	return online, nil
+}
+
+// SelectPair fetches the node list and randomly selects an entry/exit pair.
+// The selection is cryptographically random and happens entirely client-side.
+func (s *NodeSelector) SelectPair(ctx context.Context) (*NodePair, error) {
+	nodes, err := s.FetchNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return PairNodes(nodes)
+}
+
+// PairNodes selects a random entry/exit pair from a list of nodes.
+// Exported for testing with pre-fetched node lists.
+func PairNodes(nodes []types.NodeInfo) (*NodePair, error) {
+	var entryNodes, exitNodes []types.NodeInfo
+
+	for _, n := range nodes {
+		switch n.Role {
+		case types.RoleEntry:
+			entryNodes = append(entryNodes, n)
+		case types.RoleExit:
+			exitNodes = append(exitNodes, n)
+		case types.RoleBoth:
+			entryNodes = append(entryNodes, n)
+			exitNodes = append(exitNodes, n)
+		}
+	}
+
+	if len(entryNodes) == 0 {
+		return nil, ErrNoEntryNodes
+	}
+	if len(exitNodes) == 0 {
+		return nil, ErrNoExitNodes
+	}
+
+	// Cryptographically random selection.
+	entry, err := randomPick(entryNodes)
+	if err != nil {
+		return nil, fmt.Errorf("selecting entry: %w", err)
+	}
+
+	// Ensure exit != entry (if possible).
+	var candidateExits []types.NodeInfo
+	for _, n := range exitNodes {
+		if n.NostrPubkey != entry.NostrPubkey {
+			candidateExits = append(candidateExits, n)
+		}
+	}
+	if len(candidateExits) == 0 {
+		// Only one node serves both roles — allow same node.
+		candidateExits = exitNodes
+	}
+
+	exit, err := randomPick(candidateExits)
+	if err != nil {
+		return nil, fmt.Errorf("selecting exit: %w", err)
+	}
+
+	return &NodePair{Entry: entry, Exit: exit}, nil
+}
+
+// randomPick selects a random element from a slice using crypto/rand.
+func randomPick(nodes []types.NodeInfo) (types.NodeInfo, error) {
+	if len(nodes) == 1 {
+		return nodes[0], nil
+	}
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(nodes))))
+	if err != nil {
+		return types.NodeInfo{}, fmt.Errorf("crypto random: %w", err)
+	}
+	return nodes[n.Int64()], nil
+}

--- a/internal/client/selector_test.go
+++ b/internal/client/selector_test.go
@@ -1,0 +1,302 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Radi-Labs/ARFL/pkg/types"
+	"github.com/elnosh/gonuts/cashu"
+)
+
+// --- NodeSelector tests ---
+
+func TestPairNodes_HappyPath(t *testing.T) {
+	nodes := []types.NodeInfo{
+		{NostrPubkey: "entry1", Role: types.RoleEntry, ConnectURL: "http://e1:9091"},
+		{NostrPubkey: "exit1", Role: types.RoleExit, ConnectURL: "http://x1:9091"},
+		{NostrPubkey: "exit2", Role: types.RoleExit, ConnectURL: "http://x2:9091"},
+	}
+
+	pair, err := PairNodes(nodes)
+	if err != nil {
+		t.Fatalf("PairNodes: %v", err)
+	}
+	if pair.Entry.NostrPubkey != "entry1" {
+		t.Errorf("expected entry1, got %s", pair.Entry.NostrPubkey)
+	}
+	if pair.Exit.Role != types.RoleExit {
+		t.Errorf("exit should have exit role, got %s", pair.Exit.Role)
+	}
+	// Entry and exit should differ when possible.
+	if pair.Entry.NostrPubkey == pair.Exit.NostrPubkey {
+		t.Error("entry and exit should differ when multiple nodes available")
+	}
+}
+
+func TestPairNodes_BothRole(t *testing.T) {
+	nodes := []types.NodeInfo{
+		{NostrPubkey: "both1", Role: types.RoleBoth, ConnectURL: "http://b1:9091"},
+		{NostrPubkey: "both2", Role: types.RoleBoth, ConnectURL: "http://b2:9091"},
+	}
+
+	pair, err := PairNodes(nodes)
+	if err != nil {
+		t.Fatalf("PairNodes: %v", err)
+	}
+	// Both nodes serve both roles; entry != exit when possible.
+	if pair.Entry.NostrPubkey == pair.Exit.NostrPubkey {
+		t.Error("should select different nodes when two 'both' nodes available")
+	}
+}
+
+func TestPairNodes_SingleBothNode(t *testing.T) {
+	nodes := []types.NodeInfo{
+		{NostrPubkey: "only", Role: types.RoleBoth, ConnectURL: "http://only:9091"},
+	}
+
+	pair, err := PairNodes(nodes)
+	if err != nil {
+		t.Fatalf("PairNodes: %v", err)
+	}
+	// Only one node — must use same for both.
+	if pair.Entry.NostrPubkey != "only" || pair.Exit.NostrPubkey != "only" {
+		t.Error("single both-role node should serve as both entry and exit")
+	}
+}
+
+func TestPairNodes_NoEntryNodes(t *testing.T) {
+	nodes := []types.NodeInfo{
+		{NostrPubkey: "exit1", Role: types.RoleExit},
+	}
+	_, err := PairNodes(nodes)
+	if err != ErrNoEntryNodes {
+		t.Errorf("expected ErrNoEntryNodes, got %v", err)
+	}
+}
+
+func TestPairNodes_NoExitNodes(t *testing.T) {
+	nodes := []types.NodeInfo{
+		{NostrPubkey: "entry1", Role: types.RoleEntry},
+	}
+	_, err := PairNodes(nodes)
+	if err != ErrNoExitNodes {
+		t.Errorf("expected ErrNoExitNodes, got %v", err)
+	}
+}
+
+func TestPairNodes_EmptyList(t *testing.T) {
+	_, err := PairNodes(nil)
+	if err != ErrNoEntryNodes {
+		t.Errorf("expected ErrNoEntryNodes for empty list, got %v", err)
+	}
+}
+
+func TestFetchNodes_FromHub(t *testing.T) {
+	// Mock hub server returning a node list.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes" {
+			http.NotFound(w, r)
+			return
+		}
+		resp := map[string]interface{}{
+			"nodes": []map[string]interface{}{
+				{
+					"info":      types.NodeInfo{NostrPubkey: "n1", Role: types.RoleEntry, ConnectURL: "http://n1:9091"},
+					"online":    true,
+					"last_seen": "2025-01-01T00:00:00Z",
+				},
+				{
+					"info":      types.NodeInfo{NostrPubkey: "n2", Role: types.RoleExit, ConnectURL: "http://n2:9091"},
+					"online":    true,
+					"last_seen": "2025-01-01T00:00:00Z",
+				},
+				{
+					"info":      types.NodeInfo{NostrPubkey: "offline", Role: types.RoleBoth, ConnectURL: "http://off:9091"},
+					"online":    false,
+					"last_seen": "2024-12-01T00:00:00Z",
+				},
+			},
+			"count": 3,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	sel := NewNodeSelector(srv.URL)
+	nodes, err := sel.FetchNodes(context.Background())
+	if err != nil {
+		t.Fatalf("FetchNodes: %v", err)
+	}
+	// Should get 2 online nodes (offline filtered out).
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 online nodes, got %d", len(nodes))
+	}
+}
+
+func TestSelectPair_IntegrationWithMockHub(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"nodes": []map[string]interface{}{
+				{
+					"info":      types.NodeInfo{NostrPubkey: "e1", Role: types.RoleEntry, ConnectURL: "http://e1:9091"},
+					"online":    true,
+					"last_seen": "2025-01-01T00:00:00Z",
+				},
+				{
+					"info":      types.NodeInfo{NostrPubkey: "x1", Role: types.RoleExit, ConnectURL: "http://x1:9091"},
+					"online":    true,
+					"last_seen": "2025-01-01T00:00:00Z",
+				},
+			},
+			"count": 2,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	sel := NewNodeSelector(srv.URL)
+	pair, err := sel.SelectPair(context.Background())
+	if err != nil {
+		t.Fatalf("SelectPair: %v", err)
+	}
+	if pair.Entry.NostrPubkey != "e1" {
+		t.Errorf("expected entry e1, got %s", pair.Entry.NostrPubkey)
+	}
+	if pair.Exit.NostrPubkey != "x1" {
+		t.Errorf("expected exit x1, got %s", pair.Exit.NostrPubkey)
+	}
+}
+
+// --- CashuConnector tests ---
+
+func TestCashuConnector_HappyPath(t *testing.T) {
+	// Mock node /connect endpoint.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/connect" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+
+		var req CashuConnectRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", 400)
+			return
+		}
+
+		if len(req.Proofs) == 0 || req.WGPubkey == "" {
+			http.Error(w, "missing fields", 400)
+			return
+		}
+
+		// Calculate bytes from proofs.
+		var totalSats uint64
+		for _, p := range req.Proofs {
+			totalSats += p.Amount
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ConnectResult{
+			TunnelIP:     "10.100.0.2/32",
+			NodeWGPubkey: "fakeNodePubkey==",
+			BytesAllowed: int64(totalSats) * 1_000_000,
+		})
+	}))
+	defer srv.Close()
+
+	cc := NewCashuConnector()
+	proofs := cashu.Proofs{
+		{Amount: 10, Id: "test-keyset", Secret: "sec1", C: "02abc"},
+	}
+
+	result, err := cc.ConnectWithProofs(context.Background(), srv.URL, proofs, "clientPubKey==")
+	if err != nil {
+		t.Fatalf("ConnectWithProofs: %v", err)
+	}
+	if result.TunnelIP != "10.100.0.2/32" {
+		t.Errorf("expected tunnel IP 10.100.0.2/32, got %s", result.TunnelIP)
+	}
+	if result.BytesAllowed != 10_000_000 {
+		t.Errorf("expected 10M bytes, got %d", result.BytesAllowed)
+	}
+}
+
+func TestCashuConnector_NodeRejectsProofs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"detail": "proof already spent"})
+	}))
+	defer srv.Close()
+
+	cc := NewCashuConnector()
+	proofs := cashu.Proofs{{Amount: 1, Id: "ks", Secret: "s", C: "02c"}}
+
+	_, err := cc.ConnectWithProofs(context.Background(), srv.URL, proofs, "pk==")
+	if err == nil {
+		t.Fatal("expected error for rejected proofs")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestCashuConnector_EmptyProofs(t *testing.T) {
+	cc := NewCashuConnector()
+	_, err := cc.ConnectWithProofs(context.Background(), "http://localhost", nil, "pk==")
+	if err == nil {
+		t.Fatal("expected error for empty proofs")
+	}
+}
+
+func TestCashuConnector_EmptyPubkey(t *testing.T) {
+	cc := NewCashuConnector()
+	proofs := cashu.Proofs{{Amount: 1, Id: "ks", Secret: "s", C: "02c"}}
+	_, err := cc.ConnectWithProofs(context.Background(), "http://localhost", proofs, "")
+	if err == nil {
+		t.Fatal("expected error for empty pubkey")
+	}
+}
+
+func TestConnectPair_BothSucceed(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		ip := "10.100.0.2/32"
+		if callCount == 2 {
+			ip = "10.100.0.3/32"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ConnectResult{
+			TunnelIP:     ip,
+			NodeWGPubkey: "nodePub==",
+			BytesAllowed: 5_000_000,
+		})
+	}))
+	defer srv.Close()
+
+	cc := NewCashuConnector()
+	pair := &NodePair{
+		Entry: types.NodeInfo{ConnectURL: srv.URL, Role: types.RoleEntry},
+		Exit:  types.NodeInfo{ConnectURL: srv.URL, Role: types.RoleExit},
+	}
+
+	entry, exit, err := cc.ConnectPair(
+		context.Background(),
+		pair,
+		cashu.Proofs{{Amount: 5, Id: "ks", Secret: "s1", C: "02a"}},
+		cashu.Proofs{{Amount: 5, Id: "ks", Secret: "s2", C: "02b"}},
+		"clientPub==",
+	)
+	if err != nil {
+		t.Fatalf("ConnectPair: %v", err)
+	}
+	if entry.TunnelIP != "10.100.0.2/32" {
+		t.Errorf("entry tunnel IP: got %s", entry.TunnelIP)
+	}
+	if exit.TunnelIP != "10.100.0.3/32" {
+		t.Errorf("exit tunnel IP: got %s", exit.TunnelIP)
+	}
+}

--- a/internal/discovery/cashu_api.go
+++ b/internal/discovery/cashu_api.go
@@ -50,6 +50,8 @@ func (api *DiscoveryAPI) SetMint(mint *ecash.Mint, mintStore ecash.Store) {
 	api.mux.HandleFunc("/v1/swap", api.handleSwap)
 	// NUT-07: Token state check
 	api.mux.HandleFunc("/v1/checkstate", api.handleCheckState)
+	// ARFL-specific: Token redemption (nodes verify + burn client tokens)
+	api.mux.HandleFunc("/v1/redeem", api.handleRedeem)
 }
 
 // cashuRateCheck applies rate limiting and returns the client IP.
@@ -463,4 +465,93 @@ func writeError(w http.ResponseWriter, status int, detail string) {
 		"detail": detail,
 		"code":   status,
 	})
+}
+
+// handleRedeem verifies and burns Cashu proofs presented by nodes on behalf
+// of clients. This is the ARFL-specific token redemption endpoint.
+//
+// Flow: Client gives proof to node → node calls POST /v1/redeem → hub verifies
+// proof, marks it spent, returns bytes_allowed. Node then grants WG access.
+//
+// The hub sees which proofs were redeemed but CANNOT link them to the original
+// buyer (Cashu blind signature property).
+func (api *DiscoveryAPI) handleRedeem(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if api.cashuRateCheck(w, r) == "" {
+		return
+	}
+
+	var req struct {
+		Proofs     cashu.Proofs `json:"proofs"`
+		NodePubkey string       `json:"node_pubkey"`
+	}
+	if err := json.NewDecoder(limitedBody(r)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if len(req.Proofs) == 0 {
+		writeError(w, http.StatusBadRequest, "proofs required")
+		return
+	}
+	if len(req.Proofs) > maxSwapInputs {
+		writeError(w, http.StatusBadRequest, "too many proofs (max 64)")
+		return
+	}
+	if req.NodePubkey == "" {
+		writeError(w, http.StatusBadRequest, "node_pubkey required")
+		return
+	}
+
+	// Use worker pool for crypto verification.
+	ctx, cancel := context.WithTimeout(r.Context(), cryptoTimeout)
+	defer cancel()
+
+	spentProofs, err := api.cryptoPool.VerifyProofs(ctx, req.Proofs)
+	if err != nil {
+		switch err {
+		case ecash.ErrInvalidProof:
+			writeError(w, http.StatusBadRequest, "invalid proof")
+		case ecash.ErrProofAlreadySpent:
+			writeError(w, http.StatusConflict, "proof already spent")
+		case ecash.ErrDuplicateProofs:
+			writeError(w, http.StatusBadRequest, "duplicate proofs")
+		case ecash.ErrUnknownKeyset:
+			writeError(w, http.StatusBadRequest, "unknown keyset")
+		default:
+			log.Printf("[ecash] redeem verify error: %v", err)
+			writeError(w, http.StatusInternalServerError, "verification failed")
+		}
+		return
+	}
+
+	// Mark proofs as spent.
+	if err := api.mintStore.SaveSpentProofs(spentProofs); err != nil {
+		log.Printf("[ecash] redeem save spent error: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to record redemption")
+		return
+	}
+
+	// Calculate total sats redeemed → convert to bytes allowed.
+	// 1 sat = 1 MB for MVP (simple, adjustable later via config).
+	var totalSats uint64
+	for _, p := range req.Proofs {
+		totalSats += p.Amount
+	}
+	bytesAllowed := int64(totalSats) * 1_000_000 // 1 sat = 1 MB
+
+	resp := struct {
+		OK           bool   `json:"ok"`
+		BytesAllowed int64  `json:"bytes_allowed"`
+		SatsRedeemed uint64 `json:"sats_redeemed"`
+	}{
+		OK:           true,
+		BytesAllowed: bytesAllowed,
+		SatsRedeemed: totalSats,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
 }


### PR DESCRIPTION
## What
Client-side privacy layer — hub never learns which node pair the user chose.

### New files
- `internal/client/selector.go` — NodeSelector fetches nodes from hub, crypto-random client-side pairing
- `internal/client/cashu_connector.go` — CashuConnector presents Cashu proofs to nodes (replaces RSA blind tokens)
- `internal/client/selector_test.go` — 14 new tests

### Modified
- `internal/discovery/cashu_api.go` — Added `POST /v1/redeem` endpoint (nodes verify + burn client proofs → bytes_allowed)
- `cmd/arfl-hub/main.go` — Registered /v1/redeem route

### Privacy model
1. Client mints Cashu tokens via hub (blind signatures — hub can't link buyer to token)
2. Client selects entry/exit nodes **client-side** (hub never sees the pairing)
3. Client presents tokens to nodes → nodes call hub `/v1/redeem` → hub burns tokens, returns bandwidth quota
4. Hub sees tokens were redeemed but **cannot link** them to buyer or node pair

### Tests
All existing + 14 new tests pass.