### PR TITLE
Phase 10: Node-side Cashu gate + hub redeemer

### DIFF
--- a/cmd/arfl-node/main.go
+++ b/cmd/arfl-node/main.go
@@ -123,7 +123,7 @@ func main() {
 	adminServer := control.NewServer(wgMgr, quotaMgr, cfg.Interface)
 
 	// Wire token-gated /connect if hub_url and hub_pubkey_file are configured.
-	var connectAddr string
+	connectAddr := cfg.ConnectAddr
 	if cfg.HubURL != "" && cfg.HubPubkeyFile != "" {
 		pubKey, err := credentials.LoadPublicKey(cfg.HubPubkeyFile)
 		if err != nil {
@@ -134,29 +134,41 @@ func main() {
 		verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{pubKey})
 		gate := client.NewTokenGate(verifier, cfg.HubURL, wgPubKeyB64)
 
-		// Derive subnet from tunnel IP (e.g. "10.100.0.1/24" → "10.100.0").
 		subnet := deriveTunnelSubnet(cfg.TunnelIP)
 		adminServer.EnableTokenGate(gate, wgPubKeyB64, subnet)
-
-		// Start public-facing /connect API on a separate port if configured.
-		// The admin API stays on localhost; the connect API is exposed to clients.
-		connectAddr = cfg.ConnectAddr
-		if connectAddr != "" {
-			connectMux := http.NewServeMux()
-			connectMux.HandleFunc("POST /connect", adminServer.HandleConnect)
-			connectMux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.Write([]byte(`{"status":"healthy"}`))
-			})
-			go func() {
-				log.Printf("[node] public /connect API on %s", connectAddr)
-				if err := http.ListenAndServe(connectAddr, connectMux); err != nil {
-					log.Fatalf("connect API: %v", err)
-				}
-			}()
-		}
 	} else {
-		log.Println("[node] token gate disabled (no hub_url or hub_pubkey_file configured)")
+		log.Println("[node] RSA token gate disabled (no hub_url or hub_pubkey_file)")
+	}
+
+	// Wire Cashu-gated /cashu-connect if hub_url and nostr_privkey are configured.
+	if cfg.HubURL != "" && cfg.NostrPrivkey != "" {
+		nodeKPForCashu, err := nostr.KeyPairFromPrivHex(cfg.NostrPrivkey)
+		if err != nil {
+			log.Fatalf("parse nostr key for cashu gate: %v", err)
+		}
+		redeemer := client.NewHubRedeemer(cfg.HubURL, nodeKPForCashu.PubkeyHex())
+		subnet := deriveTunnelSubnet(cfg.TunnelIP)
+		adminServer.EnableCashuGate(redeemer, wgPubKeyB64, subnet)
+	} else {
+		log.Println("[node] Cashu gate disabled (no hub_url or nostr_privkey)")
+	}
+
+	// Start public-facing connect API on a separate port if configured.
+	// Serves both /connect (RSA) and /cashu-connect (Cashu) on the same port.
+	if connectAddr != "" {
+		connectMux := http.NewServeMux()
+		connectMux.HandleFunc("POST /connect", adminServer.HandleConnect)
+		connectMux.HandleFunc("POST /cashu-connect", adminServer.HandleCashuConnect)
+		connectMux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"status":"healthy"}`))
+		})
+		go func() {
+			log.Printf("[node] public connect API on %s (/connect + /cashu-connect)", connectAddr)
+			if err := http.ListenAndServe(connectAddr, connectMux); err != nil {
+				log.Fatalf("connect API: %v", err)
+			}
+		}()
 	}
 
 	go func() {

--- a/cmd/arfl-node/main.go
+++ b/cmd/arfl-node/main.go
@@ -16,11 +16,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Radi-Labs/ARFL/internal/client"
 	"github.com/Radi-Labs/ARFL/internal/config"
 	"github.com/Radi-Labs/ARFL/internal/control"
 	"github.com/Radi-Labs/ARFL/internal/credentials"
 	"github.com/Radi-Labs/ARFL/internal/discovery"
+	"github.com/Radi-Labs/ARFL/internal/node"
 	"github.com/Radi-Labs/ARFL/internal/nostr"
 	"github.com/Radi-Labs/ARFL/internal/quota"
 	"github.com/Radi-Labs/ARFL/internal/routing"
@@ -132,7 +132,7 @@ func main() {
 		log.Printf("[node] loaded hub public key: %s (%d bytes/token)", pubKey.KeyID, pubKey.BytesPerToken)
 
 		verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{pubKey})
-		gate := client.NewTokenGate(verifier, cfg.HubURL, wgPubKeyB64)
+		gate := node.NewTokenGate(verifier, cfg.HubURL, wgPubKeyB64)
 
 		subnet := deriveTunnelSubnet(cfg.TunnelIP)
 		adminServer.EnableTokenGate(gate, wgPubKeyB64, subnet)
@@ -146,7 +146,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("parse nostr key for cashu gate: %v", err)
 		}
-		redeemer := client.NewHubRedeemer(cfg.HubURL, nodeKPForCashu.PubkeyHex())
+		redeemer := node.NewHubRedeemer(cfg.HubURL, nodeKPForCashu.PubkeyHex())
 		subnet := deriveTunnelSubnet(cfg.TunnelIP)
 		adminServer.EnableCashuGate(redeemer, wgPubKeyB64, subnet)
 	} else {

--- a/internal/client/hub_redeemer.go
+++ b/internal/client/hub_redeemer.go
@@ -1,0 +1,124 @@
+// HubRedeemer is an HTTP client that nodes use to call the hub's
+// POST /v1/redeem endpoint to verify and burn Cashu proofs presented
+// by connecting clients.
+//
+// The node receives Cashu proofs from a client, forwards them to the
+// hub for verification + spend-marking, and gets back the bandwidth
+// allowance if the proofs are valid.
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/elnosh/gonuts/cashu"
+)
+
+// HubRedeemer errors.
+var (
+	ErrRedeemInvalidProof = errors.New("hub rejected proofs: invalid")
+	ErrRedeemAlreadySpent = errors.New("hub rejected proofs: already spent")
+	ErrRedeemHubDown      = errors.New("hub unreachable or returned server error")
+	ErrRedeemRateLimited  = errors.New("hub rate-limited this node")
+	ErrRedeemCircuitOpen  = errors.New("hub circuit breaker is open (LN down)")
+)
+
+// CashuRedeemResult is returned on successful Cashu proof redemption.
+type CashuRedeemResult struct {
+	BytesAllowed int64  `json:"bytes_allowed"`
+	SatsRedeemed uint64 `json:"sats_redeemed"`
+}
+
+// HubRedeemer calls the hub's /v1/redeem endpoint.
+type HubRedeemer struct {
+	hubURL     string
+	nodePubkey string // This node's Nostr pubkey (identifies the caller).
+	httpClient *http.Client
+}
+
+// NewHubRedeemer creates a redeemer pointed at the given hub.
+// nodePubkey is this node's Nostr public key (hex).
+func NewHubRedeemer(hubURL, nodePubkey string) *HubRedeemer {
+	return &HubRedeemer{
+		hubURL:     hubURL,
+		nodePubkey: nodePubkey,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+// redeemRequest matches the hub's expected JSON body.
+type redeemRequest struct {
+	Proofs     cashu.Proofs `json:"proofs"`
+	NodePubkey string       `json:"node_pubkey"`
+}
+
+// redeemResponse matches the hub's success JSON.
+type redeemResponse struct {
+	OK           bool   `json:"ok"`
+	BytesAllowed int64  `json:"bytes_allowed"`
+	SatsRedeemed uint64 `json:"sats_redeemed"`
+}
+
+// Redeem sends proofs to the hub for verification and burn.
+// Returns the bandwidth allowance on success.
+func (hr *HubRedeemer) Redeem(ctx context.Context, proofs cashu.Proofs) (*CashuRedeemResult, error) {
+	body, err := json.Marshal(redeemRequest{
+		Proofs:     proofs,
+		NodePubkey: hr.nodePubkey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal redeem request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hr.hubURL+"/v1/redeem", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := hr.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrRedeemHubDown, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var result redeemResponse
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return nil, fmt.Errorf("decode redeem response: %w", err)
+		}
+		if !result.OK {
+			return nil, fmt.Errorf("hub returned ok=false")
+		}
+		return &CashuRedeemResult{
+			BytesAllowed: result.BytesAllowed,
+			SatsRedeemed: result.SatsRedeemed,
+		}, nil
+
+	case http.StatusBadRequest:
+		return nil, ErrRedeemInvalidProof
+
+	case http.StatusConflict:
+		return nil, ErrRedeemAlreadySpent
+
+	case http.StatusTooManyRequests:
+		return nil, ErrRedeemRateLimited
+
+	case http.StatusServiceUnavailable:
+		return nil, ErrRedeemCircuitOpen
+
+	default:
+		return nil, fmt.Errorf("%w: status %d: %s", ErrRedeemHubDown, resp.StatusCode, respBody)
+	}
+}

--- a/internal/control/api.go
+++ b/internal/control/api.go
@@ -3,7 +3,9 @@ package control
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"github.com/Radi-Labs/ARFL/internal/credentials"
 	"github.com/Radi-Labs/ARFL/internal/quota"
 	"github.com/Radi-Labs/ARFL/internal/wg"
+	"github.com/elnosh/gonuts/cashu"
 )
 
 // Server provides an HTTP admin API for the node daemon.
@@ -32,6 +35,9 @@ type Server struct {
 	gate     *client.TokenGate
 	ipPool   *tunnelIPPool
 	wgPubkey string // This node's WireGuard public key (returned to clients).
+
+	// Cashu gate (optional — set via EnableCashuGate).
+	redeemer *client.HubRedeemer
 }
 
 // NewServer creates a new admin API server.
@@ -361,4 +367,114 @@ func (p *tunnelIPPool) Count() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return len(p.allocated)
+}
+
+// --- Cashu-gated connect (Phase 10) ---
+
+const maxCashuConnectProofs = 64
+
+// CashuConnectRequest is sent by clients presenting Cashu proofs.
+type CashuConnectRequest struct {
+	Proofs   cashu.Proofs `json:"proofs"`
+	WGPubkey string       `json:"wg_pubkey"`
+}
+
+// EnableCashuGate wires Cashu proof verification into the admin server.
+// When enabled, clients can POST /cashu-connect with Cashu proofs to get
+// WireGuard access. The node forwards proofs to the hub for verification.
+//
+// Both gates (RSA and Cashu) can coexist — they register on different paths.
+func (s *Server) EnableCashuGate(redeemer *client.HubRedeemer, wgPubkey, subnet string) {
+	s.redeemer = redeemer
+	s.wgPubkey = wgPubkey
+	if s.ipPool == nil {
+		s.ipPool = newTunnelIPPool(subnet)
+	}
+	s.mux.HandleFunc("POST /cashu-connect", s.handleCashuConnect)
+	log.Printf("[admin] Cashu-gated /cashu-connect enabled (subnet=%s.0/24)", subnet)
+}
+
+// HandleCashuConnect is the exported handler, used when the connect API
+// is served on a separate public-facing port.
+func (s *Server) HandleCashuConnect(w http.ResponseWriter, r *http.Request) {
+	s.handleCashuConnect(w, r)
+}
+
+func (s *Server) handleCashuConnect(w http.ResponseWriter, r *http.Request) {
+	if s.redeemer == nil {
+		writeError(w, http.StatusServiceUnavailable, "cashu verification not configured")
+		return
+	}
+
+	var req CashuConnectRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64*1024)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.WGPubkey == "" {
+		writeError(w, http.StatusBadRequest, "missing wg_pubkey")
+		return
+	}
+	if len(req.Proofs) == 0 {
+		writeError(w, http.StatusBadRequest, "no proofs provided")
+		return
+	}
+	if len(req.Proofs) > maxCashuConnectProofs {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("too many proofs (max %d)", maxCashuConnectProofs))
+		return
+	}
+
+	// Forward proofs to hub for verification + spend-marking.
+	result, err := s.redeemer.Redeem(r.Context(), req.Proofs)
+	if err != nil {
+		switch {
+		case errors.Is(err, client.ErrRedeemAlreadySpent):
+			writeError(w, http.StatusConflict, "proofs already spent")
+		case errors.Is(err, client.ErrRedeemInvalidProof):
+			writeError(w, http.StatusUnauthorized, "invalid proofs")
+		case errors.Is(err, client.ErrRedeemRateLimited):
+			writeError(w, http.StatusTooManyRequests, "hub rate-limited — try later")
+		case errors.Is(err, client.ErrRedeemCircuitOpen):
+			writeError(w, http.StatusServiceUnavailable, "hub payment system temporarily down")
+		default:
+			log.Printf("[cashu-connect] hub redeem error: %v", err)
+			writeError(w, http.StatusBadGateway, "hub verification failed")
+		}
+		return
+	}
+
+	// Proofs verified and burned. Grant WireGuard access.
+	tunnelIP, err := s.ipPool.Allocate(req.WGPubkey)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, fmt.Sprintf("no IPs available: %v", err))
+		return
+	}
+
+	if err := s.wgMgr.AddPeer(s.iface, wg.PeerConfig{
+		PublicKey:  req.WGPubkey,
+		AllowedIPs: []string{tunnelIP + "/32"},
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("add peer: %v", err))
+		return
+	}
+
+	if err := s.quotaMgr.SetQuota(tunnelIP, result.BytesAllowed); err != nil {
+		log.Printf("[cashu-connect] warning: set quota for %s: %v", tunnelIP, err)
+	}
+
+	pubkeyLog := req.WGPubkey
+	if len(pubkeyLog) > 16 {
+		pubkeyLog = pubkeyLog[:16] + "..."
+	}
+	log.Printf("[cashu-connect] peer %s connected (ip=%s, bytes=%d, sats=%d)",
+		pubkeyLog, tunnelIP, result.BytesAllowed, result.SatsRedeemed)
+
+	writeJSON(w, http.StatusOK, ConnectResponse{
+		Status:       "connected",
+		TunnelIP:     tunnelIP + "/32",
+		NodeWGPubkey: s.wgPubkey,
+		BytesAllowed: result.BytesAllowed,
+		FirstSpend:   true,
+	})
 }

--- a/internal/control/api.go
+++ b/internal/control/api.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Radi-Labs/ARFL/internal/client"
 	"github.com/Radi-Labs/ARFL/internal/credentials"
+	"github.com/Radi-Labs/ARFL/internal/node"
 	"github.com/Radi-Labs/ARFL/internal/quota"
 	"github.com/Radi-Labs/ARFL/internal/wg"
 	"github.com/elnosh/gonuts/cashu"
@@ -32,12 +32,12 @@ type Server struct {
 	mux      *http.ServeMux
 
 	// Token gate (optional — set via EnableTokenGate).
-	gate     *client.TokenGate
+	gate     *node.TokenGate
 	ipPool   *tunnelIPPool
 	wgPubkey string // This node's WireGuard public key (returned to clients).
 
 	// Cashu gate (optional — set via EnableCashuGate).
-	redeemer *client.HubRedeemer
+	redeemer *node.HubRedeemer
 }
 
 // NewServer creates a new admin API server.
@@ -172,7 +172,7 @@ func writeError(w http.ResponseWriter, code int, msg string) {
 // WireGuard access. wgPubkey is this node's WireGuard public key
 // (base64), returned to clients so they can configure their tunnel.
 // subnet is the tunnel subnet (e.g. "10.100.0") from which IPs are assigned.
-func (s *Server) EnableTokenGate(gate *client.TokenGate, wgPubkey, subnet string) {
+func (s *Server) EnableTokenGate(gate *node.TokenGate, wgPubkey, subnet string) {
 	s.gate = gate
 	s.wgPubkey = wgPubkey
 	s.ipPool = newTunnelIPPool(subnet)
@@ -384,7 +384,7 @@ type CashuConnectRequest struct {
 // WireGuard access. The node forwards proofs to the hub for verification.
 //
 // Both gates (RSA and Cashu) can coexist — they register on different paths.
-func (s *Server) EnableCashuGate(redeemer *client.HubRedeemer, wgPubkey, subnet string) {
+func (s *Server) EnableCashuGate(redeemer *node.HubRedeemer, wgPubkey, subnet string) {
 	s.redeemer = redeemer
 	s.wgPubkey = wgPubkey
 	if s.ipPool == nil {
@@ -429,13 +429,13 @@ func (s *Server) handleCashuConnect(w http.ResponseWriter, r *http.Request) {
 	result, err := s.redeemer.Redeem(r.Context(), req.Proofs)
 	if err != nil {
 		switch {
-		case errors.Is(err, client.ErrRedeemAlreadySpent):
+		case errors.Is(err, node.ErrRedeemAlreadySpent):
 			writeError(w, http.StatusConflict, "proofs already spent")
-		case errors.Is(err, client.ErrRedeemInvalidProof):
+		case errors.Is(err, node.ErrRedeemInvalidProof):
 			writeError(w, http.StatusUnauthorized, "invalid proofs")
-		case errors.Is(err, client.ErrRedeemRateLimited):
+		case errors.Is(err, node.ErrRedeemRateLimited):
 			writeError(w, http.StatusTooManyRequests, "hub rate-limited — try later")
-		case errors.Is(err, client.ErrRedeemCircuitOpen):
+		case errors.Is(err, node.ErrRedeemCircuitOpen):
 			writeError(w, http.StatusServiceUnavailable, "hub payment system temporarily down")
 		default:
 			log.Printf("[cashu-connect] hub redeem error: %v", err)

--- a/internal/control/cashu_connect_test.go
+++ b/internal/control/cashu_connect_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Radi-Labs/ARFL/internal/client"
+	"github.com/Radi-Labs/ARFL/internal/node"
 	"github.com/Radi-Labs/ARFL/internal/quota"
 	"github.com/Radi-Labs/ARFL/internal/wg"
 	"github.com/elnosh/gonuts/cashu"
@@ -37,7 +37,7 @@ func setupCashuEnv(t *testing.T, hubHandler http.HandlerFunc) (*Server, *wg.Mock
 	srv := NewServer(mockWG, mockQuota, "wg-test")
 
 	hub := mockHubRedeem(t, hubHandler)
-	redeemer := client.NewHubRedeemer(hub.URL, "test-node-pubkey")
+	redeemer := node.NewHubRedeemer(hub.URL, "test-node-pubkey")
 	srv.EnableCashuGate(redeemer, "fakeNodePubkey==", "10.100.0")
 
 	return srv, mockWG
@@ -186,7 +186,7 @@ func TestCashuConnect_HubDown(t *testing.T) {
 	srv := NewServer(mockWG, mockQuota, "wg-test")
 
 	// Point redeemer at a non-existent URL.
-	redeemer := client.NewHubRedeemer("http://127.0.0.1:1", "node-pk")
+	redeemer := node.NewHubRedeemer("http://127.0.0.1:1", "node-pk")
 	srv.EnableCashuGate(redeemer, "nodePub==", "10.100.0")
 
 	reqBody, _ := json.Marshal(CashuConnectRequest{

--- a/internal/control/cashu_connect_test.go
+++ b/internal/control/cashu_connect_test.go
@@ -1,0 +1,219 @@
+package control
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Radi-Labs/ARFL/internal/client"
+	"github.com/Radi-Labs/ARFL/internal/quota"
+	"github.com/Radi-Labs/ARFL/internal/wg"
+	"github.com/elnosh/gonuts/cashu"
+)
+
+// mockHubRedeem creates a mock hub /v1/redeem endpoint.
+func mockHubRedeem(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/redeem", handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func setupCashuEnv(t *testing.T, hubHandler http.HandlerFunc) (*Server, *wg.MockManager) {
+	t.Helper()
+	mockWG := wg.NewMockManager()
+	mockQuota := quota.NewNoopEnforcer()
+	mockWG.CreateInterface(wg.InterfaceConfig{
+		Name:       "wg-test",
+		PrivateKey: "YPrKbTKgZ1HE/9bVKMYXEEaGFzk7Rp1G1dCfOBqvYW0=",
+		ListenPort: 51820,
+		Address:    "10.100.0.1/24",
+	})
+
+	srv := NewServer(mockWG, mockQuota, "wg-test")
+
+	hub := mockHubRedeem(t, hubHandler)
+	redeemer := client.NewHubRedeemer(hub.URL, "test-node-pubkey")
+	srv.EnableCashuGate(redeemer, "fakeNodePubkey==", "10.100.0")
+
+	return srv, mockWG
+}
+
+func TestCashuConnect_HappyPath(t *testing.T) {
+	srv, mockWG := setupCashuEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":            true,
+			"bytes_allowed": 10_000_000,
+			"sats_redeemed": 10,
+		})
+	})
+
+	reqBody, _ := json.Marshal(CashuConnectRequest{
+		Proofs:   cashu.Proofs{{Amount: 10, Id: "ks1", Secret: "s1", C: "02abc"}},
+		WGPubkey: "clientPubKey123==",
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/cashu-connect", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	srv.handleCashuConnect(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp ConnectResponse
+	json.NewDecoder(rr.Body).Decode(&resp)
+
+	if resp.Status != "connected" {
+		t.Errorf("expected status 'connected', got %q", resp.Status)
+	}
+	if resp.TunnelIP == "" {
+		t.Error("expected non-empty tunnel IP")
+	}
+	if resp.NodeWGPubkey != "fakeNodePubkey==" {
+		t.Errorf("expected node pubkey, got %q", resp.NodeWGPubkey)
+	}
+	if resp.BytesAllowed != 10_000_000 {
+		t.Errorf("expected 10M bytes, got %d", resp.BytesAllowed)
+	}
+
+	// Verify WG peer was added.
+	if mockWG.PeerCount("wg-test") != 1 {
+		t.Fatalf("expected 1 peer, got %d", mockWG.PeerCount("wg-test"))
+	}
+}
+
+func TestCashuConnect_AlreadySpent(t *testing.T) {
+	srv, _ := setupCashuEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"detail": "proof already spent",
+			"code":   409,
+		})
+	})
+
+	reqBody, _ := json.Marshal(CashuConnectRequest{
+		Proofs:   cashu.Proofs{{Amount: 5, Id: "ks1", Secret: "spent", C: "02abc"}},
+		WGPubkey: "pk==",
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/cashu-connect", bytes.NewReader(reqBody))
+	srv.handleCashuConnect(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCashuConnect_InvalidProofs(t *testing.T) {
+	srv, _ := setupCashuEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"detail": "invalid proof",
+			"code":   400,
+		})
+	})
+
+	reqBody, _ := json.Marshal(CashuConnectRequest{
+		Proofs:   cashu.Proofs{{Amount: 1, Id: "bad", Secret: "s", C: "02c"}},
+		WGPubkey: "pk==",
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/cashu-connect", bytes.NewReader(reqBody))
+	srv.handleCashuConnect(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCashuConnect_MissingPubkey(t *testing.T) {
+	srv, _ := setupCashuEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("hub should not be called")
+	})
+
+	reqBody, _ := json.Marshal(CashuConnectRequest{
+		Proofs:   cashu.Proofs{{Amount: 1, Id: "ks", Secret: "s", C: "02c"}},
+		WGPubkey: "", // empty
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/cashu-connect", bytes.NewReader(reqBody))
+	srv.handleCashuConnect(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestCashuConnect_NoProofs(t *testing.T) {
+	srv, _ := setupCashuEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("hub should not be called")
+	})
+
+	reqBody, _ := json.Marshal(CashuConnectRequest{
+		Proofs:   nil,
+		WGPubkey: "pk==",
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/cashu-connect", bytes.NewReader(reqBody))
+	srv.handleCashuConnect(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestCashuConnect_HubDown(t *testing.T) {
+	mockWG := wg.NewMockManager()
+	mockQuota := quota.NewNoopEnforcer()
+	mockWG.CreateInterface(wg.InterfaceConfig{
+		Name: "wg-test", PrivateKey: "YPrKbTKgZ1HE/9bVKMYXEEaGFzk7Rp1G1dCfOBqvYW0=",
+		ListenPort: 51820, Address: "10.100.0.1/24",
+	})
+	srv := NewServer(mockWG, mockQuota, "wg-test")
+
+	// Point redeemer at a non-existent URL.
+	redeemer := client.NewHubRedeemer("http://127.0.0.1:1", "node-pk")
+	srv.EnableCashuGate(redeemer, "nodePub==", "10.100.0")
+
+	reqBody, _ := json.Marshal(CashuConnectRequest{
+		Proofs:   cashu.Proofs{{Amount: 5, Id: "ks", Secret: "s", C: "02c"}},
+		WGPubkey: "pk==",
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/cashu-connect", bytes.NewReader(reqBody))
+	srv.handleCashuConnect(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCashuConnect_NotConfigured(t *testing.T) {
+	mockWG := wg.NewMockManager()
+	mockQuota := quota.NewNoopEnforcer()
+	srv := NewServer(mockWG, mockQuota, "wg-test")
+	// Do NOT call EnableCashuGate.
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/cashu-connect", nil)
+	srv.handleCashuConnect(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", rr.Code)
+	}
+}

--- a/internal/control/connect_test.go
+++ b/internal/control/connect_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Radi-Labs/ARFL/internal/client"
 	"github.com/Radi-Labs/ARFL/internal/credentials"
 	"github.com/Radi-Labs/ARFL/internal/lightning"
+	"github.com/Radi-Labs/ARFL/internal/node"
 	"github.com/Radi-Labs/ARFL/internal/payments"
 	"github.com/Radi-Labs/ARFL/internal/quota"
 	"github.com/Radi-Labs/ARFL/internal/store"
@@ -68,7 +69,7 @@ func setupConnectEnv(t *testing.T) *connectEnv {
 	nodeVerifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
 		credentials.ExportPublicKey(denomKey),
 	})
-	gate := client.NewTokenGate(nodeVerifier, hubServer.URL, "test-node-pubkey")
+	gate := node.NewTokenGate(nodeVerifier, hubServer.URL, "test-node-pubkey")
 	srv.EnableTokenGate(gate, "test-node-wg-pubkey", "10.100.0")
 
 	return &connectEnv{

--- a/internal/node/hub_redeemer.go
+++ b/internal/node/hub_redeemer.go
@@ -1,11 +1,9 @@
+// Package node provides the node-side SDK for ARFL node operators.
+//
 // HubRedeemer is an HTTP client that nodes use to call the hub's
 // POST /v1/redeem endpoint to verify and burn Cashu proofs presented
-// by connecting clients.
-//
-// The node receives Cashu proofs from a client, forwards them to the
-// hub for verification + spend-marking, and gets back the bandwidth
-// allowance if the proofs are valid.
-package client
+// by connecting VPN clients.
+package node
 
 import (
 	"bytes"

--- a/internal/node/tokengate.go
+++ b/internal/node/tokengate.go
@@ -1,12 +1,11 @@
-// Package client provides both the bandwidth purchase SDK (BandwidthClient)
-// and the node-side token verification SDK (TokenGate).
+// Package node provides the node-side SDK for ARFL node operators.
 //
-// TokenGate is used by arfl-node to verify and spend BlindTokens presented
-// by clients. It verifies the RSA blind signature locally, then calls the
-// Hub's /spend endpoint for double-spend prevention.
+// TokenGate verifies and spends BlindTokens presented by VPN clients.
+// It verifies the RSA blind signature locally, then calls the Hub's
+// /spend endpoint for double-spend prevention.
 //
 // The node never needs the Hub's private key — only the public key.
-package client
+package node
 
 import (
 	"bytes"
@@ -14,6 +13,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -126,4 +126,18 @@ func (g *TokenGate) VerifyOnly(token *credentials.BlindToken) (*SpendResult, err
 		FirstSpend:    true, // assumed — no Hub check
 		BytesPerToken: denom,
 	}, nil
+}
+
+// readAPIError extracts an error message from a non-200 hub response.
+func readAPIError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+		return fmt.Errorf("hub API error (%d): %s", resp.StatusCode, errResp.Error)
+	}
+
+	return fmt.Errorf("hub API error (%d): %s", resp.StatusCode, string(body))
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Radi-Labs/ARFL/internal/control"
 	"github.com/Radi-Labs/ARFL/internal/credentials"
 	"github.com/Radi-Labs/ARFL/internal/lightning"
+	"github.com/Radi-Labs/ARFL/internal/node"
 	"github.com/Radi-Labs/ARFL/internal/payments"
 	"github.com/Radi-Labs/ARFL/internal/quota"
 	"github.com/Radi-Labs/ARFL/internal/store"
@@ -118,7 +119,7 @@ func TestFullProtocol_PurchaseRedeemSpend(t *testing.T) {
 	nodeVerifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
 		credentials.ExportPublicKey(denomKey),
 	})
-	gate := client.NewTokenGate(nodeVerifier, server.URL, "node-entry-1")
+	gate := node.NewTokenGate(nodeVerifier, server.URL, "node-entry-1")
 
 	for i, token := range result.Tokens {
 		spend, err := gate.VerifyAndSpend(context.Background(), token)
@@ -144,7 +145,7 @@ func TestFullProtocol_PurchaseRedeemSpend(t *testing.T) {
 	// If a malicious client replays the same token at another node,
 	// the Hub detects it.
 	t.Log("Testing double-spend detection...")
-	secondGate := client.NewTokenGate(nodeVerifier, server.URL, "node-exit-2")
+	secondGate := node.NewTokenGate(nodeVerifier, server.URL, "node-exit-2")
 
 	doubleSpend, err := secondGate.VerifyAndSpend(context.Background(), result.Tokens[0])
 	if err != nil {
@@ -237,7 +238,7 @@ func TestMultipleClients_IndependentEntitlements(t *testing.T) {
 	}
 
 	// All tokens from both clients should be independently valid.
-	gate := client.NewTokenGate(
+	gate := node.NewTokenGate(
 		credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
 			credentials.ExportPublicKey(denomKey),
 		}),
@@ -407,7 +408,7 @@ func TestFullFlow_PurchaseConnectTunnel(t *testing.T) {
 	nodeVerifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
 		credentials.ExportPublicKey(denomKey),
 	})
-	entryGate := client.NewTokenGate(nodeVerifier, hubServer.URL, "entryNodePub")
+	entryGate := node.NewTokenGate(nodeVerifier, hubServer.URL, "entryNodePub")
 	entryServer.EnableTokenGate(entryGate, "entryNodePub", "10.100.0")
 
 	entryHTTP := httptest.NewServer(http.HandlerFunc(entryServer.HandleConnect))
@@ -422,7 +423,7 @@ func TestFullFlow_PurchaseConnectTunnel(t *testing.T) {
 	exitQuota := quota.NewNoopEnforcer()
 	exitServer := control.NewServer(exitWG, exitQuota, "wg-exit")
 
-	exitGate := client.NewTokenGate(nodeVerifier, hubServer.URL, "exitNodePub")
+	exitGate := node.NewTokenGate(nodeVerifier, hubServer.URL, "exitNodePub")
 	exitServer.EnableTokenGate(exitGate, "exitNodePub", "10.200.0")
 
 	exitHTTP := httptest.NewServer(http.HandlerFunc(exitServer.HandleConnect))

--- a/test/integration/stride_test.go
+++ b/test/integration/stride_test.go
@@ -1,4 +1,4 @@
-package client
+package integration
 
 import (
 	"context"
@@ -18,7 +18,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Radi-Labs/ARFL/internal/client"
 	"github.com/Radi-Labs/ARFL/internal/credentials"
+	"github.com/Radi-Labs/ARFL/internal/node"
+	"github.com/Radi-Labs/ARFL/test/testutil"
 )
 
 // Phase 5 STRIDE tests for the client-side attack surfaces:
@@ -37,7 +40,7 @@ import (
 func TestSTRIDE_TokenGate_WrongDenomKey(t *testing.T) {
 	// THREAT: Attacker runs a rogue hub that signs tokens with a different
 	// key. Nodes must reject tokens signed by keys they don't trust.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	// Generate a completely separate key (rogue hub).
 	rogueKey, _ := credentials.GenerateDenominationKey("key-100mb", 100_000_000)
@@ -58,9 +61,9 @@ func TestSTRIDE_TokenGate_WrongDenomKey(t *testing.T) {
 
 	// Node trusts only the real hub's key.
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
 	spend, err := gate.VerifyAndSpend(context.Background(), rogueToken)
 	if err != nil {
@@ -74,19 +77,19 @@ func TestSTRIDE_TokenGate_WrongDenomKey(t *testing.T) {
 func TestSTRIDE_TokenGate_VersionMismatch(t *testing.T) {
 	// THREAT: Attacker forges a token with a future version number to
 	// bypass version-specific checks.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
 	// Get a legitimately signed token, then change its version.
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-version")
 	token := result.Tokens[0]
@@ -146,7 +149,7 @@ func TestSTRIDE_Client_RogueHubSignatures(t *testing.T) {
 
 	// Client talks to rogue hub but verifies against real key.
 	realKey, _ := credentials.GenerateDenominationKey("key-100mb", 100_000_000)
-	bwClient := NewBandwidthClient(rogue.URL, rogueKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(rogue.URL, rogueKey.PublicKey, "key-100mb")
 
 	result, err := bwClient.RedeemTokens(context.Background(), "deadbeef", 2, "nonce-rogue")
 	if err != nil {
@@ -157,7 +160,7 @@ func TestSTRIDE_Client_RogueHubSignatures(t *testing.T) {
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
 		credentials.ExportPublicKey(realKey),
 	})
-	gate := NewTokenGate(verifier, "http://irrelevant", "node-1")
+	gate := node.NewTokenGate(verifier, "http://irrelevant", "node-1")
 
 	for i, token := range result.Tokens {
 		spend, _ := gate.VerifyOnly(token)
@@ -174,18 +177,18 @@ func TestSTRIDE_Client_RogueHubSignatures(t *testing.T) {
 func TestSTRIDE_TokenGate_TamperedSecret(t *testing.T) {
 	// THREAT: Man-in-the-middle tampers with the token secret after
 	// the client receives valid tokens but before presenting to node.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-tamper")
 	token := result.Tokens[0]
@@ -208,18 +211,18 @@ func TestSTRIDE_TokenGate_TamperedSecret(t *testing.T) {
 func TestSTRIDE_TokenGate_TamperedSignature(t *testing.T) {
 	// THREAT: Attacker modifies the signature bytes to try an
 	// existential forgery.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-sig-tamper")
 	token := result.Tokens[0]
@@ -351,28 +354,28 @@ func TestSTRIDE_TokenFile_TamperedOnDisk(t *testing.T) {
 func TestSTRIDE_TokenGate_SpendCreatesDurableRecord(t *testing.T) {
 	// REQUIREMENT: After a node spends a token, the Hub has a durable
 	// record. A second spend of the same token must return first_spend=false.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
 
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-repudiation")
 
 	// Spend from node A.
-	gateA := NewTokenGate(verifier, hub.server.URL, "node-A")
+	gateA := node.NewTokenGate(verifier, hub.Server.URL, "node-A")
 	spendA, _ := gateA.VerifyAndSpend(context.Background(), result.Tokens[0])
 	if !spendA.FirstSpend {
 		t.Fatal("first spend should be true")
 	}
 
 	// Spend same token from node B — Hub proves the token was already spent.
-	gateB := NewTokenGate(verifier, hub.server.URL, "node-B")
+	gateB := node.NewTokenGate(verifier, hub.Server.URL, "node-B")
 	spendB, _ := gateB.VerifyAndSpend(context.Background(), result.Tokens[0])
 	if spendB.FirstSpend {
 		t.Fatal("Hub must record spend durably — replay detected")
@@ -386,8 +389,8 @@ func TestSTRIDE_TokenGate_SpendCreatesDurableRecord(t *testing.T) {
 func TestSTRIDE_Client_HubErrorDoesNotLeakPreimage(t *testing.T) {
 	// THREAT: Hub returns error messages that include the preimage or
 	// payment hash in cleartext. SDK errors must not propagate these.
-	hub := setupTestHub(t)
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	hub := testutil.SetupTestHub(t)
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 
 	// Try to redeem with a fake preimage that doesn't exist.
 	fakePreimage := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -444,18 +447,18 @@ func TestSTRIDE_Keystore_PublicKeyNoPrivateMaterial(t *testing.T) {
 func TestSTRIDE_TokenGate_SpendDoesNotLeakTokenSecret(t *testing.T) {
 	// REQUIREMENT: When the Hub receives /spend, the response should
 	// not echo the token_secret back. We verify via the SDK's result.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-no-echo")
 
 	spend, err := gate.VerifyAndSpend(context.Background(), result.Tokens[0])
@@ -478,8 +481,8 @@ func TestSTRIDE_TokenGate_SpendDoesNotLeakTokenSecret(t *testing.T) {
 
 func TestSTRIDE_Client_RedeemZeroTokens(t *testing.T) {
 	// THREAT: Client requests zero or negative token count.
-	hub := setupTestHub(t)
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	hub := testutil.SetupTestHub(t)
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 
 	_, err := bwClient.RedeemTokens(context.Background(), "somepreimage", 0, "nonce-zero")
 	if err == nil {
@@ -494,12 +497,12 @@ func TestSTRIDE_Client_RedeemZeroTokens(t *testing.T) {
 
 func TestSTRIDE_TokenGate_EmptyToken(t *testing.T) {
 	// THREAT: Node receives completely empty or zero-value token fields.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
 	cases := []struct {
 		name  string
@@ -539,25 +542,25 @@ func TestSTRIDE_TokenGate_EmptyToken(t *testing.T) {
 func TestSTRIDE_TokenGate_HubUnreachable(t *testing.T) {
 	// THREAT: Hub goes down. VerifyAndSpend should return an error
 	// (not silently pass), so the node can fall back to VerifyOnly.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
 
 	// Get a valid token.
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-unreachable")
 
 	// Shut down the hub.
-	hub.server.Close()
+	hub.Server.Close()
 
 	// Point gate at the now-dead hub.
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
 	_, err := gate.VerifyAndSpend(context.Background(), result.Tokens[0])
 	if err == nil {
@@ -582,23 +585,23 @@ func TestSTRIDE_VerifyOnly_DoubleSpendBypasses(t *testing.T) {
 	// THREAT: Attacker presents the same token to multiple nodes using
 	// VerifyOnly (offline mode). Each node accepts it. This is the
 	// bounded risk of grace period mode — it must be documented.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
 
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-grace")
 
 	// Same token verified at 3 different nodes in offline mode.
 	// ALL should pass — this is the documented risk.
 	for i := 0; i < 3; i++ {
-		gate := NewTokenGate(verifier, hub.server.URL, fmt.Sprintf("node-%d", i))
+		gate := node.NewTokenGate(verifier, hub.Server.URL, fmt.Sprintf("node-%d", i))
 		spend, err := gate.VerifyOnly(result.Tokens[0])
 		if err != nil {
 			t.Fatalf("node %d: VerifyOnly: %v", i, err)
@@ -609,13 +612,13 @@ func TestSTRIDE_VerifyOnly_DoubleSpendBypasses(t *testing.T) {
 	}
 
 	// But VerifyAndSpend (online) catches the double-spend after first use.
-	gateOnline := NewTokenGate(verifier, hub.server.URL, "node-online-1")
+	gateOnline := node.NewTokenGate(verifier, hub.Server.URL, "node-online-1")
 	spend1, _ := gateOnline.VerifyAndSpend(context.Background(), result.Tokens[0])
 	if !spend1.FirstSpend {
 		t.Fatal("first online spend should succeed")
 	}
 
-	gateOnline2 := NewTokenGate(verifier, hub.server.URL, "node-online-2")
+	gateOnline2 := node.NewTokenGate(verifier, hub.Server.URL, "node-online-2")
 	spend2, _ := gateOnline2.VerifyAndSpend(context.Background(), result.Tokens[0])
 	if spend2.FirstSpend {
 		t.Fatal("second online spend must be detected as double-spend")
@@ -626,13 +629,13 @@ func TestSTRIDE_Client_CrossKeyRedeem(t *testing.T) {
 	// THREAT: Client redeems tokens for key_id "key-1gb" but presents
 	// them claiming key_id "key-100mb" to get more bandwidth per token.
 	// The signature won't verify because it was signed under a different key.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-cross-key")
 
@@ -641,9 +644,9 @@ func TestSTRIDE_Client_CrossKeyRedeem(t *testing.T) {
 	token.KeyID = "key-1gb" // pretend it's a bigger denomination
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
 	spend, err := gate.VerifyAndSpend(context.Background(), token)
 	if err != nil {
@@ -662,17 +665,17 @@ func TestSTRIDE_Client_CrossKeyRedeem(t *testing.T) {
 func TestSTRIDE_ConcurrentSpend_SameTokenMultipleNodes(t *testing.T) {
 	// THREAT: Multiple nodes race to spend the same token concurrently.
 	// Exactly one must get first_spend=true.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
 
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-race")
 
 	var wg sync.WaitGroup
@@ -684,7 +687,7 @@ func TestSTRIDE_ConcurrentSpend_SameTokenMultipleNodes(t *testing.T) {
 		wg.Add(1)
 		go func(nodeID int) {
 			defer wg.Done()
-			gate := NewTokenGate(verifier, hub.server.URL, fmt.Sprintf("node-%d", nodeID))
+			gate := node.NewTokenGate(verifier, hub.Server.URL, fmt.Sprintf("node-%d", nodeID))
 			spend, err := gate.VerifyAndSpend(context.Background(), result.Tokens[0])
 			if err != nil {
 				atomic.AddInt32(&errorCount, 1)
@@ -709,7 +712,7 @@ func TestSTRIDE_ConcurrentSpend_SameTokenMultipleNodes(t *testing.T) {
 func TestSTRIDE_ConcurrentRedeem_IndependentEntitlements(t *testing.T) {
 	// THREAT: Multiple clients redeem concurrently from different
 	// entitlements. Ensure no cross-contamination.
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	var wg sync.WaitGroup
 	var successCount int32
@@ -719,15 +722,15 @@ func TestSTRIDE_ConcurrentRedeem_IndependentEntitlements(t *testing.T) {
 		go func(clientID int) {
 			defer wg.Done()
 
-			bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+			bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 			purchase, err := bwClient.Purchase(context.Background(), "1gb")
 			if err != nil {
 				return
 			}
 
-			hub.mock.SimulateSettlement(purchase.PaymentHash)
+			hub.Mock.SimulateSettlement(purchase.PaymentHash)
 			time.Sleep(300 * time.Millisecond)
-			preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+			preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 			result, err := bwClient.RedeemTokens(
 				context.Background(), preimage, 2,

--- a/test/integration/tokengate_test.go
+++ b/test/integration/tokengate_test.go
@@ -1,28 +1,31 @@
-package client
+package integration
 
 import (
 	"context"
 	"testing"
 	"time"
 
+	"github.com/Radi-Labs/ARFL/internal/client"
 	"github.com/Radi-Labs/ARFL/internal/credentials"
+	"github.com/Radi-Labs/ARFL/internal/node"
+	"github.com/Radi-Labs/ARFL/test/testutil"
 )
 
 func TestTokenGate_VerifyAndSpend_ValidToken(t *testing.T) {
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	// Create a node-side verifier with the hub's public key.
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "test-node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "test-node-1")
 
 	// Get a valid token through the full flow.
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 	result, err := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-gate-test")
 	if err != nil {
@@ -47,18 +50,18 @@ func TestTokenGate_VerifyAndSpend_ValidToken(t *testing.T) {
 }
 
 func TestTokenGate_VerifyAndSpend_DoubleSpend(t *testing.T) {
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "test-node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "test-node-1")
 
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-double")
 
@@ -83,12 +86,12 @@ func TestTokenGate_VerifyAndSpend_DoubleSpend(t *testing.T) {
 }
 
 func TestTokenGate_VerifyAndSpend_InvalidSignature(t *testing.T) {
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "test-node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "test-node-1")
 
 	// Craft a token with a bogus signature.
 	secret, _ := credentials.GenerateTokenSecret()
@@ -110,19 +113,19 @@ func TestTokenGate_VerifyAndSpend_InvalidSignature(t *testing.T) {
 }
 
 func TestTokenGate_VerifyOnly_ValidToken(t *testing.T) {
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "test-node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "test-node-1")
 
 	// Get a valid token.
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 	result, _ := bwClient.RedeemTokens(context.Background(), preimage, 1, "nonce-verify-only")
 
@@ -144,12 +147,12 @@ func TestTokenGate_VerifyOnly_ValidToken(t *testing.T) {
 }
 
 func TestTokenGate_VerifyOnly_InvalidSignature(t *testing.T) {
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "test-node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "test-node-1")
 
 	fakeToken := &credentials.BlindToken{
 		Version:     credentials.BlindTokenVersion,
@@ -168,14 +171,14 @@ func TestTokenGate_VerifyOnly_InvalidSignature(t *testing.T) {
 }
 
 func TestTokenGate_FullFlow_PurchaseRedeemSpend(t *testing.T) {
-	hub := setupTestHub(t)
+	hub := testutil.SetupTestHub(t)
 
 	// Client side: purchase and redeem.
-	bwClient := NewBandwidthClient(hub.server.URL, hub.denomKey.PublicKey, "key-100mb")
+	bwClient := client.NewBandwidthClient(hub.Server.URL, hub.DenomKey.PublicKey, "key-100mb")
 	purchase, _ := bwClient.Purchase(context.Background(), "1gb")
-	hub.mock.SimulateSettlement(purchase.PaymentHash)
+	hub.Mock.SimulateSettlement(purchase.PaymentHash)
 	time.Sleep(200 * time.Millisecond)
-	preimage := hub.mock.GetPreimage(purchase.PaymentHash)
+	preimage := hub.Mock.GetPreimage(purchase.PaymentHash)
 
 	redeemResult, err := bwClient.RedeemTokens(context.Background(), preimage, 3, "nonce-full-gate")
 	if err != nil {
@@ -184,9 +187,9 @@ func TestTokenGate_FullFlow_PurchaseRedeemSpend(t *testing.T) {
 
 	// Node side: verify and spend each token.
 	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
-		credentials.ExportPublicKey(hub.denomKey),
+		credentials.ExportPublicKey(hub.DenomKey),
 	})
-	gate := NewTokenGate(verifier, hub.server.URL, "node-1")
+	gate := node.NewTokenGate(verifier, hub.Server.URL, "node-1")
 
 	for i, token := range redeemResult.Tokens {
 		spend, err := gate.VerifyAndSpend(context.Background(), token)

--- a/test/testutil/hub.go
+++ b/test/testutil/hub.go
@@ -1,0 +1,61 @@
+// Package testutil provides shared test helpers for ARFL integration tests.
+package testutil
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Radi-Labs/ARFL/internal/credentials"
+	"github.com/Radi-Labs/ARFL/internal/lightning"
+	"github.com/Radi-Labs/ARFL/internal/payments"
+	"github.com/Radi-Labs/ARFL/internal/store"
+)
+
+// TestHub is an in-process hub with blind signatures enabled.
+type TestHub struct {
+	Server   *httptest.Server
+	Mock     *lightning.MockClient
+	DenomKey *credentials.DenominationKey
+}
+
+// SetupTestHub creates a full hub environment for tests.
+func SetupTestHub(t *testing.T) *TestHub {
+	t.Helper()
+
+	dir := t.TempDir()
+	db, err := store.Open(dir + "/test.db")
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	secret := []byte("test-secret-key-for-hmac-32bytes!")
+	issuer := credentials.NewHMACIssuer("key-1", secret)
+
+	mock := lightning.NewMockClient()
+
+	api := payments.NewPurchaseAPI(db, mock, issuer)
+	api.StartSettlementListener(context.Background())
+	t.Cleanup(func() { api.Stop() })
+
+	denomKey, err := credentials.GenerateDenominationKey("key-100mb", 100_000_000)
+	if err != nil {
+		t.Fatalf("GenerateDenominationKey: %v", err)
+	}
+
+	mint := credentials.NewRSABlindMint([]*credentials.DenominationKey{denomKey})
+	verifier := credentials.NewRSABlindVerifier([]*credentials.DenominationKey{
+		credentials.ExportPublicKey(denomKey),
+	})
+	api.EnableBlindSignatures(mint, verifier, "key-100mb")
+
+	server := httptest.NewServer(api.Handler())
+	t.Cleanup(func() { server.Close() })
+
+	return &TestHub{
+		Server:   server,
+		Mock:     mock,
+		DenomKey: denomKey,
+	}
+}


### PR DESCRIPTION
## What
Nodes can now accept Cashu ecash proofs from clients and verify them with the hub.

### New files
- `internal/client/hub_redeemer.go` — HTTP client for calling hub `POST /v1/redeem`
- `internal/control/cashu_connect_test.go` — 7 tests for the node-side Cashu flow

### Modified
- `internal/control/api.go` — Added `EnableCashuGate()`, `POST /cashu-connect` handler
- `cmd/arfl-node/main.go` — Wired Cashu gate, refactored to single connect listener serving both RSA + Cashu paths

### Full Cashu flow now complete
```
Client → mints tokens (hub /v1/mint)
       → selects nodes client-side (selector.go)
       → presents proofs to node (POST /cashu-connect)
           → node calls hub (POST /v1/redeem)
           → hub verifies + burns proofs
           → node grants WG access
```

Hub cannot link buyer → token → node pair (Chaumian blind signatures).

### Tests
All existing + 7 new tests pass.