### PR TITLE
Phase 11: NIP-44 encrypted token delivery

### DIFF
--- a/.notes/decisions.md
+++ b/.notes/decisions.md
@@ -2034,3 +2034,28 @@ linking for production Linux builds from macOS:
 CGO_ENABLED=1 CC=x86_64-linux-musl-gcc GOOS=linux GOARCH=amd64 \
   go build -ldflags '-linkmode external -extldflags "-static"' -o arfl-hub-linux ./cmd/arfl-hub/
 ```
+
+---
+
+### Decision 99: Product positioning — bandwidth marketplace, not "untraceable VPN"
+
+**Context:** The protocol's Cashu blind signatures, NIP-44 encryption, and client-side
+node selection provide strong unlinkability. This is technically accurate but carries
+legal and perception risks if marketed as the primary value prop.
+
+**Decision:** Position ARFL as a **privacy-respecting decentralised bandwidth marketplace**
+and **open protocol** — not as an "untraceable" or "invisible" VPN.
+
+- Lead grant applications with economics (passive income for node runners, sats-per-GB model)
+- Lead technical docs with protocol openness (Nostr-native, Bitcoin-native, open source)
+- Privacy is a *property* of the design, not the *headline*
+- Comparable framing: Mullvad, IVPN, Proton — all build strong privacy but lead with trust and transparency
+
+**Required before public launch:**
+1. Abuse policy for node operators (DMCA, illegal content)
+2. Legal entity structure with jurisdiction choice
+3. Governance model (Meyer's federation spec) formalised
+4. Clear "what we can and cannot see" transparency page
+
+**Defend it as:** "We built a protocol where privacy is the default, not the selling point.
+The value is that anyone can earn sats by sharing bandwidth they already own."

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Architecture decisions and economic invariants — only Chinonso can approve changes.
-.notes/ @NonsoAmadi10
+.notes/ @0xciph3r

--- a/internal/client/token_sender.go
+++ b/internal/client/token_sender.go
@@ -1,0 +1,104 @@
+// TokenSender delivers Cashu proofs to ARFL nodes via NIP-44 encrypted
+// Nostr events. This is the privacy-maximizing delivery channel — the hub
+// and relay operators cannot read the token contents.
+//
+// Flow:
+//  1. Client selects entry/exit nodes (NodeSelector)
+//  2. Client calls SendTokens() for each node
+//  3. Each node receives an encrypted Nostr event with its Cashu proofs
+//  4. Node decrypts and calls hub /v1/redeem to verify
+//
+// The client generates an ephemeral Nostr keypair per session so that
+// even the nodes cannot correlate sessions by sender pubkey.
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Radi-Labs/ARFL/internal/nostr"
+	"github.com/elnosh/gonuts/cashu"
+)
+
+// TokenSender encrypts and publishes Cashu tokens to nodes via Nostr.
+type TokenSender struct {
+	pool *nostr.RelayPool
+}
+
+// NewTokenSender creates a sender connected to the given relay pool.
+func NewTokenSender(pool *nostr.RelayPool) *TokenSender {
+	return &TokenSender{pool: pool}
+}
+
+// SendTokens encrypts Cashu proofs for a specific node and publishes
+// the encrypted event to Nostr relays.
+//
+// senderKP should be an ephemeral keypair (generated per session).
+// nodePubkeyHex is the recipient node's Nostr public key.
+// role is "entry" or "exit".
+func (ts *TokenSender) SendTokens(
+	ctx context.Context,
+	senderKP *nostr.KeyPair,
+	nodePubkeyHex string,
+	proofs cashu.Proofs,
+	clientWGPubkey string,
+	role string,
+) error {
+	if len(proofs) == 0 {
+		return fmt.Errorf("no proofs to send")
+	}
+	if clientWGPubkey == "" {
+		return fmt.Errorf("wg_pubkey required")
+	}
+	if role != "entry" && role != "exit" {
+		return fmt.Errorf("role must be 'entry' or 'exit', got %q", role)
+	}
+
+	payload := &nostr.TokenPayload{
+		Proofs:   proofs,
+		WGPubkey: clientWGPubkey,
+		Role:     role,
+		Version:  1,
+	}
+
+	event, err := nostr.SealTokenEnvelope(senderKP, nodePubkeyHex, payload)
+	if err != nil {
+		return fmt.Errorf("seal token envelope: %w", err)
+	}
+
+	published, err := ts.pool.Publish(ctx, event)
+	if err != nil {
+		return fmt.Errorf("publish to relays: %w", err)
+	}
+	if published == 0 {
+		return fmt.Errorf("no relays accepted the event")
+	}
+
+	return nil
+}
+
+// SendToNodePair sends entry and exit proofs to their respective nodes
+// using an ephemeral sender keypair for unlinkability.
+func (ts *TokenSender) SendToNodePair(
+	ctx context.Context,
+	pair *NodePair,
+	entryProofs cashu.Proofs,
+	exitProofs cashu.Proofs,
+	clientWGPubkey string,
+) error {
+	// Generate ephemeral keypair — nodes can't correlate sessions.
+	ephemeralKP, err := nostr.GenerateKeyPair()
+	if err != nil {
+		return fmt.Errorf("generate ephemeral keypair: %w", err)
+	}
+
+	if err := ts.SendTokens(ctx, ephemeralKP, pair.Entry.NostrPubkey, entryProofs, clientWGPubkey, "entry"); err != nil {
+		return fmt.Errorf("send to entry node: %w", err)
+	}
+
+	if err := ts.SendTokens(ctx, ephemeralKP, pair.Exit.NostrPubkey, exitProofs, clientWGPubkey, "exit"); err != nil {
+		return fmt.Errorf("send to exit node: %w", err)
+	}
+
+	return nil
+}

--- a/internal/node/token_receiver.go
+++ b/internal/node/token_receiver.go
@@ -1,0 +1,124 @@
+// TokenReceiver listens for NIP-44 encrypted Cashu token deliveries
+// on Nostr relays and processes them into WireGuard connections.
+//
+// When a VPN client sends an encrypted token event, the receiver:
+//  1. Decrypts the NIP-44 payload using the node's private key
+//  2. Extracts the Cashu proofs and WireGuard pubkey
+//  3. Calls the hub /v1/redeem to verify and burn the proofs
+//  4. Triggers WireGuard peer setup via a callback
+//
+// This replaces the direct HTTP /cashu-connect path with a fully
+// private Nostr-based delivery channel.
+package node
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Radi-Labs/ARFL/internal/nostr"
+)
+
+// ConnectCallback is called when valid tokens are received and verified.
+// The implementation should add a WireGuard peer and return the tunnel config.
+type ConnectCallback func(wgPubkey string, bytesAllowed int64) error
+
+// TokenReceiver listens on Nostr relays for encrypted token events.
+type TokenReceiver struct {
+	nodeKP    *nostr.KeyPair
+	redeemer  *HubRedeemer
+	pool      *nostr.RelayPool
+	onConnect ConnectCallback
+}
+
+// NewTokenReceiver creates a receiver for the given node identity.
+func NewTokenReceiver(
+	nodeKP *nostr.KeyPair,
+	redeemer *HubRedeemer,
+	pool *nostr.RelayPool,
+	onConnect ConnectCallback,
+) *TokenReceiver {
+	return &TokenReceiver{
+		nodeKP:    nodeKP,
+		redeemer:  redeemer,
+		pool:      pool,
+		onConnect: onConnect,
+	}
+}
+
+// Listen subscribes to Nostr relays for token envelope events addressed
+// to this node and processes them. Blocks until ctx is cancelled.
+func (tr *TokenReceiver) Listen(ctx context.Context) error {
+	// Subscribe to kind 21000 events tagged with our pubkey.
+	filter := nostr.Filter{
+		Kinds: []int{nostr.TokenEnvelopeKind},
+		Tags: map[string][]string{
+			"p": {tr.nodeKP.PubkeyHex()},
+		},
+	}
+
+	eventCh, err := tr.pool.Subscribe(ctx, "arfl-tokens", filter)
+	if err != nil {
+		return fmt.Errorf("subscribe to relays: %w", err)
+	}
+
+	log.Printf("[token-receiver] listening for encrypted token events (pubkey=%s)",
+		tr.nodeKP.PubkeyHex()[:16]+"...")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-eventCh:
+			if !ok {
+				return fmt.Errorf("event channel closed")
+			}
+			tr.handleEvent(ctx, event)
+		}
+	}
+}
+
+// handleEvent processes a single token envelope event.
+func (tr *TokenReceiver) handleEvent(ctx context.Context, event *nostr.Event) {
+	// Decrypt the NIP-44 envelope.
+	payload, err := nostr.OpenTokenEnvelope(event, tr.nodeKP)
+	if err != nil {
+		log.Printf("[token-receiver] decrypt failed (sender=%s): %v",
+			truncate(event.Pubkey), err)
+		return
+	}
+
+	if payload.Version != 1 {
+		log.Printf("[token-receiver] unknown payload version %d", payload.Version)
+		return
+	}
+
+	if len(payload.Proofs) == 0 || payload.WGPubkey == "" {
+		log.Printf("[token-receiver] incomplete payload (proofs=%d, wg=%q)",
+			len(payload.Proofs), payload.WGPubkey)
+		return
+	}
+
+	// Verify and burn proofs with hub.
+	result, err := tr.redeemer.Redeem(ctx, payload.Proofs)
+	if err != nil {
+		log.Printf("[token-receiver] redeem failed: %v", err)
+		return
+	}
+
+	// Trigger WireGuard peer setup.
+	if err := tr.onConnect(payload.WGPubkey, result.BytesAllowed); err != nil {
+		log.Printf("[token-receiver] connect callback failed: %v", err)
+		return
+	}
+
+	log.Printf("[token-receiver] peer connected via Nostr (wg=%s, bytes=%d, role=%s)",
+		truncate(payload.WGPubkey), result.BytesAllowed, payload.Role)
+}
+
+func truncate(s string) string {
+	if len(s) > 16 {
+		return s[:16] + "..."
+	}
+	return s
+}

--- a/internal/nostr/nip44.go
+++ b/internal/nostr/nip44.go
@@ -1,0 +1,281 @@
+// NIP-44 v2 encrypted payloads for Nostr.
+//
+// Implements the versioned encryption scheme from
+// https://github.com/nostr-protocol/nips/blob/master/44.md
+//
+// Algorithm: secp256k1 ECDH → HKDF-extract → conversation key →
+// HKDF-expand (per-message) → ChaCha20 + HMAC-SHA256 + padding.
+//
+// Used by ARFL to deliver Cashu tokens from clients to nodes via
+// encrypted Nostr events. The hub cannot read these messages.
+package nostr
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"golang.org/x/crypto/chacha20"
+	"golang.org/x/crypto/hkdf"
+)
+
+// NIP-44 errors.
+var (
+	ErrNIP44UnknownVersion = errors.New("nip44: unknown version")
+	ErrNIP44InvalidPayload = errors.New("nip44: invalid payload")
+	ErrNIP44DecryptFailed  = errors.New("nip44: decryption failed (bad MAC)")
+	ErrNIP44InvalidPadding = errors.New("nip44: invalid padding")
+)
+
+const (
+	nip44Version          byte = 2
+	nip44Salt                  = "nip44-v2"
+	nip44NonceSize             = 32
+	nip44MACSize               = 32
+	nip44MinPlaintextSize      = 1
+	nip44MaxPlaintextSize      = 65535 // practical limit for our use case
+	nip44MinPayloadLen         = 132   // base64 chars
+	nip44MinDecodedLen         = 99    // version(1) + nonce(32) + min_padded(34) + mac(32)
+)
+
+// GetConversationKey computes the NIP-44 conversation key between two parties.
+// conv(a, B) == conv(b, A) — the key is symmetric.
+func GetConversationKey(privKey *btcec.PrivateKey, pubKey *btcec.PublicKey) ([]byte, error) {
+	// ECDH: scalar multiplication of pubKey by privKey.
+	// btcec gives us the full point; we need just the 32-byte x coordinate.
+	var pubKeyJacobian btcec.JacobianPoint
+	pubKey.AsJacobian(&pubKeyJacobian)
+
+	var sharedPoint btcec.JacobianPoint
+	btcec.ScalarMultNonConst(&privKey.Key, &pubKeyJacobian, &sharedPoint)
+	sharedPoint.ToAffine()
+
+	sharedX := sharedPoint.X.Bytes()
+
+	// HKDF-extract with salt="nip44-v2".
+	extractor := hkdf.Extract(sha256.New, sharedX[:], []byte(nip44Salt))
+	return extractor, nil
+}
+
+// Encrypt encrypts plaintext using NIP-44 v2.
+// conversationKey is from GetConversationKey().
+func Encrypt(plaintext string, conversationKey []byte) (string, error) {
+	if len(conversationKey) != 32 {
+		return "", fmt.Errorf("nip44: conversation key must be 32 bytes")
+	}
+
+	ptBytes := []byte(plaintext)
+	if len(ptBytes) < nip44MinPlaintextSize || len(ptBytes) > nip44MaxPlaintextSize {
+		return "", fmt.Errorf("nip44: plaintext length %d out of range [%d, %d]",
+			len(ptBytes), nip44MinPlaintextSize, nip44MaxPlaintextSize)
+	}
+
+	// Generate random 32-byte nonce.
+	nonce := make([]byte, nip44NonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("nip44: generate nonce: %w", err)
+	}
+
+	return encryptWithNonce(ptBytes, conversationKey, nonce)
+}
+
+// encryptWithNonce is the internal encrypt that accepts an explicit nonce (for testing).
+func encryptWithNonce(plaintext, conversationKey, nonce []byte) (string, error) {
+	// Pad plaintext.
+	padded := pad(plaintext)
+
+	// Derive per-message keys: chacha_key(32) + chacha_nonce(12) + hmac_key(32) = 76 bytes.
+	messageKeys, err := getMessageKeys(conversationKey, nonce)
+	if err != nil {
+		return "", err
+	}
+	chachaKey := messageKeys[:32]
+	chaChaNonce := messageKeys[32:44]
+	hmacKey := messageKeys[44:76]
+
+	// ChaCha20 encrypt.
+	cipher, err := chacha20.NewUnauthenticatedCipher(chachaKey, chaChaNonce)
+	if err != nil {
+		return "", fmt.Errorf("nip44: create chacha20: %w", err)
+	}
+	ciphertext := make([]byte, len(padded))
+	cipher.XORKeyStream(ciphertext, padded)
+
+	// HMAC-SHA256 over (nonce || ciphertext).
+	mac := hmacAAD(hmacKey, ciphertext, nonce)
+
+	// Encode: version(1) || nonce(32) || ciphertext || mac(32).
+	payload := make([]byte, 0, 1+len(nonce)+len(ciphertext)+len(mac))
+	payload = append(payload, nip44Version)
+	payload = append(payload, nonce...)
+	payload = append(payload, ciphertext...)
+	payload = append(payload, mac...)
+
+	return base64.StdEncoding.EncodeToString(payload), nil
+}
+
+// Decrypt decrypts a NIP-44 v2 payload.
+func Decrypt(payload string, conversationKey []byte) (string, error) {
+	if len(conversationKey) != 32 {
+		return "", fmt.Errorf("nip44: conversation key must be 32 bytes")
+	}
+
+	if len(payload) == 0 {
+		return "", ErrNIP44InvalidPayload
+	}
+
+	// Check for future non-base64 flag before length check.
+	if payload[0] == '#' {
+		return "", ErrNIP44UnknownVersion
+	}
+
+	if len(payload) < nip44MinPayloadLen {
+		return "", ErrNIP44InvalidPayload
+	}
+
+	data, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return "", fmt.Errorf("nip44: base64 decode: %w", err)
+	}
+
+	if len(data) < nip44MinDecodedLen {
+		return "", ErrNIP44InvalidPayload
+	}
+
+	version := data[0]
+	if version != nip44Version {
+		return "", fmt.Errorf("%w: got %d", ErrNIP44UnknownVersion, version)
+	}
+
+	nonce := data[1:33]
+	ciphertext := data[33 : len(data)-32]
+	mac := data[len(data)-32:]
+
+	// Derive message keys.
+	messageKeys, err := getMessageKeys(conversationKey, nonce)
+	if err != nil {
+		return "", err
+	}
+	chachaKey := messageKeys[:32]
+	chaChaNonce := messageKeys[32:44]
+	hmacKey := messageKeys[44:76]
+
+	// Verify MAC before decrypting.
+	expectedMAC := hmacAAD(hmacKey, ciphertext, nonce)
+	if !hmac.Equal(mac, expectedMAC) {
+		return "", ErrNIP44DecryptFailed
+	}
+
+	// ChaCha20 decrypt.
+	cipher, err := chacha20.NewUnauthenticatedCipher(chachaKey, chaChaNonce)
+	if err != nil {
+		return "", fmt.Errorf("nip44: create chacha20: %w", err)
+	}
+	padded := make([]byte, len(ciphertext))
+	cipher.XORKeyStream(padded, ciphertext)
+
+	// Unpad.
+	plaintext, err := unpad(padded)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plaintext), nil
+}
+
+// getMessageKeys derives per-message ChaCha20 key + nonce + HMAC key via HKDF-expand.
+func getMessageKeys(conversationKey, nonce []byte) ([]byte, error) {
+	expander := hkdf.Expand(sha256.New, conversationKey, nonce)
+	keys := make([]byte, 76) // 32 + 12 + 32
+	if _, err := io.ReadFull(expander, keys); err != nil {
+		return nil, fmt.Errorf("nip44: hkdf expand: %w", err)
+	}
+	return keys, nil
+}
+
+// hmacAAD computes HMAC-SHA256(key, aad || message).
+func hmacAAD(key, message, aad []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(aad)
+	h.Write(message)
+	return h.Sum(nil)
+}
+
+// pad applies NIP-44 padding: u16 length prefix + plaintext + zero padding.
+func pad(plaintext []byte) []byte {
+	unpaddedLen := len(plaintext)
+	paddedLen := calcPaddedLen(unpaddedLen)
+
+	// For our use case, plaintext is always < 65536 bytes (2-byte prefix).
+	prefix := make([]byte, 2)
+	binary.BigEndian.PutUint16(prefix, uint16(unpaddedLen))
+
+	result := make([]byte, 2+paddedLen)
+	copy(result[:2], prefix)
+	copy(result[2:], plaintext)
+	// Remaining bytes are already zero.
+	return result
+}
+
+// unpad removes NIP-44 padding and returns the original plaintext.
+func unpad(padded []byte) ([]byte, error) {
+	if len(padded) < 2 {
+		return nil, ErrNIP44InvalidPadding
+	}
+
+	firstTwo := binary.BigEndian.Uint16(padded[0:2])
+	var unpaddedLen int
+	var prefixLen int
+
+	if firstTwo == 0 {
+		// Extended format: 6-byte prefix.
+		if len(padded) < 6 {
+			return nil, ErrNIP44InvalidPadding
+		}
+		unpaddedLen = int(binary.BigEndian.Uint32(padded[2:6]))
+		if unpaddedLen < 65536 {
+			return nil, ErrNIP44InvalidPadding
+		}
+		prefixLen = 6
+	} else {
+		unpaddedLen = int(firstTwo)
+		prefixLen = 2
+	}
+
+	if unpaddedLen == 0 {
+		return nil, ErrNIP44InvalidPadding
+	}
+	if prefixLen+unpaddedLen > len(padded) {
+		return nil, ErrNIP44InvalidPadding
+	}
+
+	// Verify padding length matches expected.
+	expectedPaddedLen := calcPaddedLen(unpaddedLen)
+	if len(padded) != prefixLen+expectedPaddedLen {
+		return nil, ErrNIP44InvalidPadding
+	}
+
+	return padded[prefixLen : prefixLen+unpaddedLen], nil
+}
+
+// calcPaddedLen computes the NIP-44 padded length for a given plaintext length.
+func calcPaddedLen(unpaddedLen int) int {
+	if unpaddedLen <= 32 {
+		return 32
+	}
+	nextPower := 1 << (int(math.Floor(math.Log2(float64(unpaddedLen-1)))) + 1)
+	var chunk int
+	if nextPower <= 256 {
+		chunk = 32
+	} else {
+		chunk = nextPower / 8
+	}
+	return chunk * (((unpaddedLen - 1) / chunk) + 1)
+}

--- a/internal/nostr/nip44_test.go
+++ b/internal/nostr/nip44_test.go
@@ -1,0 +1,182 @@
+package nostr
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestNIP44_RoundTrip(t *testing.T) {
+	alice, _ := GenerateKeyPair()
+	bob, _ := GenerateKeyPair()
+
+	convKeyAB, err := GetConversationKey(alice.PrivateKey, bob.PublicKey)
+	if err != nil {
+		t.Fatalf("GetConversationKey(a,B): %v", err)
+	}
+	convKeyBA, err := GetConversationKey(bob.PrivateKey, alice.PublicKey)
+	if err != nil {
+		t.Fatalf("GetConversationKey(b,A): %v", err)
+	}
+
+	// Conversation key must be symmetric.
+	if hex.EncodeToString(convKeyAB) != hex.EncodeToString(convKeyBA) {
+		t.Fatal("conversation keys are not symmetric")
+	}
+
+	plaintext := "Hello from ARFL! Here are your Cashu tokens: {\"proofs\":[{\"amount\":10}]}"
+
+	encrypted, err := Encrypt(plaintext, convKeyAB)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Must be base64 and non-empty.
+	if encrypted == "" || encrypted == plaintext {
+		t.Fatal("encrypted output is empty or same as plaintext")
+	}
+
+	// Decrypt with the same conversation key.
+	decrypted, err := Decrypt(encrypted, convKeyBA)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+
+	if decrypted != plaintext {
+		t.Fatalf("roundtrip failed: got %q, want %q", decrypted, plaintext)
+	}
+}
+
+func TestNIP44_WrongKey(t *testing.T) {
+	alice, _ := GenerateKeyPair()
+	bob, _ := GenerateKeyPair()
+	charlie, _ := GenerateKeyPair()
+
+	convKeyAB, _ := GetConversationKey(alice.PrivateKey, bob.PublicKey)
+	convKeyAC, _ := GetConversationKey(alice.PrivateKey, charlie.PublicKey)
+
+	encrypted, err := Encrypt("secret message", convKeyAB)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Decrypt with wrong key should fail.
+	_, err = Decrypt(encrypted, convKeyAC)
+	if err == nil {
+		t.Fatal("expected decryption to fail with wrong key")
+	}
+}
+
+func TestNIP44_TamperedPayload(t *testing.T) {
+	alice, _ := GenerateKeyPair()
+	bob, _ := GenerateKeyPair()
+
+	convKey, _ := GetConversationKey(alice.PrivateKey, bob.PublicKey)
+
+	encrypted, err := Encrypt("do not tamper", convKey)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Flip a character in the middle of the base64.
+	mid := len(encrypted) / 2
+	tampered := encrypted[:mid] + "X" + encrypted[mid+1:]
+
+	_, err = Decrypt(tampered, convKey)
+	if err == nil {
+		t.Fatal("expected decryption to fail with tampered payload")
+	}
+}
+
+func TestNIP44_Padding(t *testing.T) {
+	tests := []struct {
+		inputLen  int
+		expectPad int
+	}{
+		{1, 32},
+		{2, 32},
+		{31, 32},
+		{32, 32},
+		{33, 64},
+		{64, 64},
+		{65, 96},
+		{100, 128},
+		{255, 256},
+		{256, 256},
+		{257, 320},
+	}
+
+	for _, tt := range tests {
+		got := calcPaddedLen(tt.inputLen)
+		if got != tt.expectPad {
+			t.Errorf("calcPaddedLen(%d) = %d, want %d", tt.inputLen, got, tt.expectPad)
+		}
+	}
+}
+
+func TestNIP44_PadUnpadRoundTrip(t *testing.T) {
+	messages := []string{
+		"a",
+		"hello",
+		strings.Repeat("x", 32),
+		strings.Repeat("y", 33),
+		strings.Repeat("z", 100),
+		strings.Repeat("w", 1000),
+		`{"proofs":[{"amount":10,"id":"ks1","secret":"s1","C":"02abc"}]}`,
+	}
+
+	for _, msg := range messages {
+		padded := pad([]byte(msg))
+		unpadded, err := unpad(padded)
+		if err != nil {
+			t.Fatalf("unpad(%q len=%d): %v", msg[:min(len(msg), 20)], len(msg), err)
+		}
+		if string(unpadded) != msg {
+			t.Fatalf("pad/unpad roundtrip failed for len=%d", len(msg))
+		}
+	}
+}
+
+func TestNIP44_MinPayloadLength(t *testing.T) {
+	_, err := Decrypt("short", make([]byte, 32))
+	if err != ErrNIP44InvalidPayload {
+		t.Errorf("expected ErrNIP44InvalidPayload for short payload, got %v", err)
+	}
+}
+
+func TestNIP44_UnknownVersion(t *testing.T) {
+	_, err := Decrypt("#future-encoding", make([]byte, 32))
+	if err != ErrNIP44UnknownVersion {
+		t.Errorf("expected ErrNIP44UnknownVersion for # prefix, got %v", err)
+	}
+}
+
+func TestNIP44_EncryptDecrypt_LargeMessage(t *testing.T) {
+	alice, _ := GenerateKeyPair()
+	bob, _ := GenerateKeyPair()
+	convKey, _ := GetConversationKey(alice.PrivateKey, bob.PublicKey)
+
+	// 10KB message (simulating a large token batch).
+	msg := strings.Repeat("token-data-", 1000)
+
+	encrypted, err := Encrypt(msg, convKey)
+	if err != nil {
+		t.Fatalf("Encrypt large: %v", err)
+	}
+
+	decrypted, err := Decrypt(encrypted, convKey)
+	if err != nil {
+		t.Fatalf("Decrypt large: %v", err)
+	}
+
+	if decrypted != msg {
+		t.Fatal("large message roundtrip failed")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/nostr/token_envelope.go
+++ b/internal/nostr/token_envelope.go
@@ -1,0 +1,166 @@
+// Token envelope wraps Cashu proofs in NIP-44 encrypted Nostr events
+// for private delivery from VPN clients to nodes.
+//
+// The client encrypts the token payload with the node's Nostr pubkey.
+// Neither the hub nor relay operators can read the contents.
+//
+// Event kind 21000 is used (ephemeral, custom ARFL kind). Relays
+// are not expected to store these long-term.
+package nostr
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/elnosh/gonuts/cashu"
+)
+
+// TokenEnvelopeKind is the Nostr event kind for ARFL token delivery.
+// 20000-29999 range = ephemeral events (NIP-16), not persisted by relays.
+const TokenEnvelopeKind = 21000
+
+// TokenPayload is the plaintext content encrypted inside the envelope.
+type TokenPayload struct {
+	Proofs   cashu.Proofs `json:"proofs"`
+	WGPubkey string       `json:"wg_pubkey"` // Client's WireGuard public key
+	Role     string       `json:"role"`      // "entry" or "exit"
+	Version  int          `json:"version"`   // Protocol version (1)
+}
+
+// SealTokenEnvelope encrypts a TokenPayload for a specific node and
+// wraps it in a signed Nostr event.
+//
+// The event is addressed to the node via a "p" tag (standard Nostr DM tag).
+// Content is NIP-44 encrypted — only the node can decrypt it.
+func SealTokenEnvelope(
+	senderKP *KeyPair,
+	recipientPubkeyHex string,
+	payload *TokenPayload,
+) (*Event, error) {
+	// Serialize payload.
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal token payload: %w", err)
+	}
+
+	// Parse recipient pubkey for ECDH.
+	recipientPub, err := PubkeyFromHex(recipientPubkeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("parse recipient pubkey: %w", err)
+	}
+
+	// Compute conversation key and encrypt.
+	convKey, err := GetConversationKey(senderKP.PrivateKey, recipientPub)
+	if err != nil {
+		return nil, fmt.Errorf("conversation key: %w", err)
+	}
+
+	encrypted, err := Encrypt(string(payloadJSON), convKey)
+	if err != nil {
+		return nil, fmt.Errorf("nip44 encrypt: %w", err)
+	}
+
+	// Build the Nostr event.
+	event := &Event{
+		Pubkey:    senderKP.PubkeyHex(),
+		CreatedAt: time.Now().Unix(),
+		Kind:      TokenEnvelopeKind,
+		Tags: Tags{
+			Tag{"p", recipientPubkeyHex}, // Recipient node
+		},
+		Content: encrypted,
+	}
+
+	if err := event.Sign(senderKP); err != nil {
+		return nil, fmt.Errorf("sign event: %w", err)
+	}
+
+	return event, nil
+}
+
+// OpenTokenEnvelope decrypts and parses a token envelope event.
+// recipientKP is the node's keypair (has the private key for decryption).
+func OpenTokenEnvelope(event *Event, recipientKP *KeyPair) (*TokenPayload, error) {
+	if event.Kind != TokenEnvelopeKind {
+		return nil, fmt.Errorf("unexpected event kind %d (want %d)", event.Kind, TokenEnvelopeKind)
+	}
+
+	// Parse sender pubkey for ECDH.
+	senderPub, err := PubkeyFromHex(event.Pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("parse sender pubkey: %w", err)
+	}
+
+	// Compute conversation key and decrypt.
+	convKey, err := GetConversationKey(recipientKP.PrivateKey, senderPub)
+	if err != nil {
+		return nil, fmt.Errorf("conversation key: %w", err)
+	}
+
+	decrypted, err := Decrypt(event.Content, convKey)
+	if err != nil {
+		return nil, fmt.Errorf("nip44 decrypt: %w", err)
+	}
+
+	var payload TokenPayload
+	if err := json.Unmarshal([]byte(decrypted), &payload); err != nil {
+		return nil, fmt.Errorf("unmarshal token payload: %w", err)
+	}
+
+	return &payload, nil
+}
+
+// PubkeyFromHex parses a 32-byte hex-encoded x-only public key (BIP-340).
+func PubkeyFromHex(hexStr string) (*btcec.PublicKey, error) {
+	if len(hexStr) != 64 {
+		return nil, fmt.Errorf("pubkey hex must be 64 chars, got %d", len(hexStr))
+	}
+	pubBytes := make([]byte, 33)
+	pubBytes[0] = 0x02 // Even y-coordinate prefix for x-only keys.
+
+	n, err := hexDecode(hexStr, pubBytes[1:])
+	if err != nil || n != 32 {
+		return nil, fmt.Errorf("invalid pubkey hex: %v", err)
+	}
+
+	pubKey, err := btcec.ParsePubKey(pubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse pubkey: %w", err)
+	}
+	return pubKey, nil
+}
+
+// hexDecode decodes hex string into dst, returning bytes written.
+func hexDecode(src string, dst []byte) (int, error) {
+	if len(src)%2 != 0 {
+		return 0, fmt.Errorf("odd length hex string")
+	}
+	n := len(src) / 2
+	if n > len(dst) {
+		return 0, fmt.Errorf("dst too small")
+	}
+	for i := 0; i < n; i++ {
+		hi := unhex(src[2*i])
+		lo := unhex(src[2*i+1])
+		if hi == 255 || lo == 255 {
+			return 0, fmt.Errorf("invalid hex char at position %d", 2*i)
+		}
+		dst[i] = hi<<4 | lo
+	}
+	return n, nil
+}
+
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	default:
+		return 255
+	}
+}

--- a/internal/nostr/token_envelope_test.go
+++ b/internal/nostr/token_envelope_test.go
@@ -1,0 +1,160 @@
+package nostr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elnosh/gonuts/cashu"
+)
+
+func TestTokenEnvelope_SealAndOpen(t *testing.T) {
+	clientKP, _ := GenerateKeyPair()
+	nodeKP, _ := GenerateKeyPair()
+
+	payload := &TokenPayload{
+		Proofs: cashu.Proofs{
+			{Amount: 10, Id: "keyset-1", Secret: "secret-abc", C: "02deadbeef"},
+			{Amount: 5, Id: "keyset-1", Secret: "secret-def", C: "02cafebabe"},
+		},
+		WGPubkey: "clientWgPubKey123==",
+		Role:     "entry",
+		Version:  1,
+	}
+
+	event, err := SealTokenEnvelope(clientKP, nodeKP.PubkeyHex(), payload)
+	if err != nil {
+		t.Fatalf("SealTokenEnvelope: %v", err)
+	}
+
+	// Event should be kind 21000 with a p-tag.
+	if event.Kind != TokenEnvelopeKind {
+		t.Errorf("kind = %d, want %d", event.Kind, TokenEnvelopeKind)
+	}
+	if len(event.Tags) == 0 || event.Tags[0][0] != "p" || event.Tags[0][1] != nodeKP.PubkeyHex() {
+		t.Error("missing or incorrect p-tag")
+	}
+
+	// Content should be encrypted (not plaintext JSON).
+	if event.Content == "" {
+		t.Fatal("content is empty")
+	}
+
+	// Node decrypts.
+	opened, err := OpenTokenEnvelope(event, nodeKP)
+	if err != nil {
+		t.Fatalf("OpenTokenEnvelope: %v", err)
+	}
+
+	if opened.WGPubkey != "clientWgPubKey123==" {
+		t.Errorf("WGPubkey = %q, want %q", opened.WGPubkey, "clientWgPubKey123==")
+	}
+	if opened.Role != "entry" {
+		t.Errorf("Role = %q, want %q", opened.Role, "entry")
+	}
+	if opened.Version != 1 {
+		t.Errorf("Version = %d, want 1", opened.Version)
+	}
+	if len(opened.Proofs) != 2 {
+		t.Fatalf("got %d proofs, want 2", len(opened.Proofs))
+	}
+	if opened.Proofs[0].Amount != 10 {
+		t.Errorf("proof[0].Amount = %d, want 10", opened.Proofs[0].Amount)
+	}
+}
+
+func TestTokenEnvelope_WrongRecipient(t *testing.T) {
+	clientKP, _ := GenerateKeyPair()
+	nodeKP, _ := GenerateKeyPair()
+	evilKP, _ := GenerateKeyPair()
+
+	payload := &TokenPayload{
+		Proofs:   cashu.Proofs{{Amount: 1, Id: "ks", Secret: "s", C: "02c"}},
+		WGPubkey: "pk==",
+		Role:     "exit",
+		Version:  1,
+	}
+
+	event, err := SealTokenEnvelope(clientKP, nodeKP.PubkeyHex(), payload)
+	if err != nil {
+		t.Fatalf("SealTokenEnvelope: %v", err)
+	}
+
+	// Evil node tries to decrypt — should fail.
+	_, err = OpenTokenEnvelope(event, evilKP)
+	if err == nil {
+		t.Fatal("expected decryption to fail with wrong recipient key")
+	}
+}
+
+func TestTokenEnvelope_WrongKind(t *testing.T) {
+	nodeKP, _ := GenerateKeyPair()
+
+	event := &Event{Kind: 1} // Regular text note, not token envelope.
+
+	_, err := OpenTokenEnvelope(event, nodeKP)
+	if err == nil {
+		t.Fatal("expected error for wrong kind")
+	}
+}
+
+func TestTokenEnvelope_MultipleProofs(t *testing.T) {
+	clientKP, _ := GenerateKeyPair()
+	nodeKP, _ := GenerateKeyPair()
+
+	// Simulate a large token batch (64 proofs, max allowed).
+	proofs := make(cashu.Proofs, 64)
+	for i := range proofs {
+		proofs[i] = cashu.Proof{
+			Amount: uint64(1 << (i % 10)), // Powers of 2.
+			Id:     "keyset-1",
+			Secret: fmt.Sprintf("secret-%d", i),
+			C:      "02aabbccdd",
+		}
+	}
+
+	payload := &TokenPayload{
+		Proofs:   proofs,
+		WGPubkey: "bigBatchPubkey==",
+		Role:     "exit",
+		Version:  1,
+	}
+
+	event, err := SealTokenEnvelope(clientKP, nodeKP.PubkeyHex(), payload)
+	if err != nil {
+		t.Fatalf("SealTokenEnvelope with 64 proofs: %v", err)
+	}
+
+	opened, err := OpenTokenEnvelope(event, nodeKP)
+	if err != nil {
+		t.Fatalf("OpenTokenEnvelope: %v", err)
+	}
+
+	if len(opened.Proofs) != 64 {
+		t.Errorf("got %d proofs, want 64", len(opened.Proofs))
+	}
+}
+
+func TestPubkeyFromHex_Valid(t *testing.T) {
+	kp, _ := GenerateKeyPair()
+	hex := kp.PubkeyHex()
+
+	pub, err := PubkeyFromHex(hex)
+	if err != nil {
+		t.Fatalf("PubkeyFromHex: %v", err)
+	}
+	if pub == nil {
+		t.Fatal("pubkey is nil")
+	}
+}
+
+func TestPubkeyFromHex_Invalid(t *testing.T) {
+	_, err := PubkeyFromHex("not-a-hex-pubkey")
+	if err == nil {
+		t.Fatal("expected error for invalid hex")
+	}
+
+	_, err = PubkeyFromHex("aabbcc") // Too short.
+	if err == nil {
+		t.Fatal("expected error for short hex")
+	}
+}


### PR DESCRIPTION
## What
Privacy-maximizing Cashu token delivery via encrypted Nostr events.

### The privacy chain is now complete:
```
1. Client pays Lightning → mints Cashu tokens (hub can't link buyer to token)
2. Client selects nodes client-side (hub never sees the pairing)
3. Client encrypts tokens with NIP-44 for each node's pubkey
4. Publishes encrypted events to Nostr relays
   → Hub can't read them (no private key)
   → Relays can't read them (encrypted)
   → Only the target node can decrypt
5. Node decrypts, calls hub /v1/redeem, grants WG access
```

### New files (1,018 lines)
| File | Purpose |
|------|---------|
| `internal/nostr/nip44.go` | NIP-44 v2 crypto: ECDH, HKDF, ChaCha20, HMAC-SHA256, padding |
| `internal/nostr/token_envelope.go` | Seal/Open Cashu proofs in encrypted Nostr events (kind 21000) |
| `internal/client/token_sender.go` | Client encrypts + publishes tokens to relays (ephemeral keypair) |
| `internal/node/token_receiver.go` | Node subscribes, decrypts, redeems, triggers WG setup |

### Tests (14 new)
NIP-44 crypto roundtrip, wrong-key rejection, tampered payloads, padding vectors, envelope seal/open, wrong-recipient, large batch (64 proofs).