### PR TITLE
perf: add pprof debug endpoint (localhost-only)

### DIFF
--- a/cmd/arfl-hub/main.go
+++ b/cmd/arfl-hub/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof" // registers /debug/pprof/* handlers on DefaultServeMux
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -293,6 +294,27 @@ func main() {
 			log.Fatalf("API server: %v", err)
 		}
 	}()
+
+	// Start pprof debug server on localhost only (not internet-reachable).
+	// Access via SSH tunnel: ssh -L 6060:127.0.0.1:6060 arfl-hub
+	// Then: go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+	//
+	// Disable by setting ARFL_PPROF=off in the environment.
+	pprofAddr := "127.0.0.1:6060"
+	if v := os.Getenv("ARFL_PPROF"); v == "off" {
+		log.Printf("[hub] pprof disabled (ARFL_PPROF=off)")
+	} else {
+		if v != "" {
+			pprofAddr = v
+		}
+		go func() {
+			// Uses http.DefaultServeMux which has pprof routes registered by the import.
+			log.Printf("[hub] pprof listening on %s (localhost only)", pprofAddr)
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+				log.Printf("[hub] pprof server error: %v", err)
+			}
+		}()
+	}
 
 	total, online := idx.NodeCount()
 	log.Printf("[hub] ready | nodes: %d total, %d online | relays: %d | settlement: every %s",


### PR DESCRIPTION
## Summary

Adds Go's built-in pprof profiling endpoint to the hub binary, bound to `127.0.0.1:6060` (not internet-reachable).

### Security model
- **Binds to localhost only** — no exposure to public internet
- Access via SSH tunnel: `ssh -L 6060:127.0.0.1:6060 arfl-hub`
- Can be disabled entirely: `ARFL_PPROF=off`

### Usage (after SSH tunnel)
```bash
# CPU profile (30 seconds)
go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30

# Heap allocations
go tool pprof http://localhost:6060/debug/pprof/heap

# Goroutine dump
curl http://localhost:6060/debug/pprof/goroutine?debug=2

# Live mutex contention
go tool pprof http://localhost:6060/debug/pprof/mutex
```

### Configuration
| Env var | Effect |
|---------|--------|
| _(unset)_ | Listen on `127.0.0.1:6060` |
| `ARFL_PPROF=off` | Disabled entirely |
| `ARFL_PPROF=127.0.0.1:9090` | Custom bind address |

### Why this matters
Unlocks production profiling for Issues #22 (alloc optimization) and #24 (load testing). We can now see exactly where CPU/memory goes under real traffic.

Closes #25