### PR TITLE
docs: update documentation for v0.1.0 + GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "README.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,38 +1,40 @@
 # ARFL
 
-**Privacy in the Dark Cloud** — A decentralised VPN protocol powered by Bitcoin.
+**Privacy-respecting bandwidth marketplace** — A decentralised VPN protocol powered by Bitcoin.
 
-ARFL is a decentralised VPN protocol that combines WireGuard, Nostr, the Bitcoin Lightning Network, and blind signatures into a self-sustaining privacy network. No accounts. No subscriptions. No logs. No token.
+ARFL is a decentralised VPN protocol that combines WireGuard, Nostr, the Bitcoin Lightning Network, and Cashu ecash into a self-sustaining privacy network. No accounts. No subscriptions. No logs. No token.
 
-Users pay per-gigabyte via Lightning. Node operators earn passive income on bandwidth they already own. The hub coordinates sessions but **mathematically cannot link buyers to their browsing activity** thanks to Chaumian blind signatures.
+Users pay per-gigabyte via Lightning. Node operators earn passive income on bandwidth they already own. The hub coordinates sessions but **mathematically cannot link buyers to their browsing activity** thanks to Cashu blind signatures (BDHKE).
 
 [![CI](https://github.com/Radi-Labs/ARFL/actions/workflows/ci.yml/badge.svg)](https://github.com/Radi-Labs/ARFL/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/Radi-Labs/ARFL)](https://github.com/Radi-Labs/ARFL/releases/latest)
 
 ## How It Works
 
 ```
 ┌──────────┐     Lightning      ┌──────────┐     Nostr relays     ┌──────────┐
 │  Client   │ ──── pay ────────► │   Hub    │ ◄── announcements ── │  Nodes   │
-│           │ ◄── blind tokens ─ │          │                      │          │
+│           │ ◄── Cashu tokens ─ │  (mint)  │                      │          │
 └─────┬─────┘                    └──────────┘                      └────┬─────┘
       │                                                                 │
-      │  present token                                                  │
+      │  NIP-44 encrypted token                                         │
       └────────────────── WireGuard tunnel ────────────────────────────►│
                           (entry → exit → internet)
 ```
 
 1. **Client** pays a Lightning invoice for bandwidth (e.g., 500 sats for 1 GB)
-2. **Hub** issues blind-signed tokens — it signs without seeing the token secrets
-3. **Client** presents a token to a **Node** via `POST /connect`
-4. **Node** verifies the RSA signature locally, then checks with the Hub for double-spend
-5. **Node** grants WireGuard access with a bandwidth quota matching the token
+2. **Hub** mints Cashu ecash tokens — blind-signed via BDHKE (Blind Diffie-Hellman Key Exchange)
+3. **Client** unblinds tokens locally — Hub mathematically cannot link tokens to the buyer
+4. **Client** encrypts tokens with NIP-44 and delivers to **Node** via Nostr relay
+5. **Node** decrypts, verifies proofs with the Hub's `/v1/redeem`, grants WireGuard access
 6. Traffic flows through a **nested two-hop WireGuard tunnel** (entry → exit → internet)
 
 ### Privacy Properties
 
 | Property | How |
 |---|---|
-| **Buyer-session unlinkability** | Blind signatures — Hub signs blinded messages, cannot link tokens to buyers |
+| **Buyer-session unlinkability** | Cashu BDHKE — Hub signs blinded messages, cannot link tokens to buyers |
+| **Token delivery privacy** | NIP-44 encryption — Hub cannot read token contents in transit |
 | **Entry node can't see destinations** | Inner WireGuard tunnel encrypts traffic end-to-end to the exit |
 | **Exit node can't see client IP** | Only sees the entry node's IP (NAT'd) |
 | **No accounts or identity** | Lightning payments require no personal information |
@@ -40,12 +42,12 @@ Users pay per-gigabyte via Lightning. Node operators earn passive income on band
 
 ### Honest Threat Model
 
-ARFL is an **online bounded-risk authorization system for bandwidth** — not offline ecash. Key caveats:
+ARFL is a **privacy-respecting bandwidth marketplace** — not an untraceable VPN. Key caveats:
 
-- The Hub is the real-time arbiter for double-spend detection. Nodes must contact it for `/spend` checks.
-- During a Hub outage, nodes fall back to offline verification (`VerifyOnly`). Risk is bounded: a replayed token can steal at most 100 MB × N_offline_nodes.
+- The Hub is the real-time arbiter for double-spend detection. Nodes must contact it for `/v1/redeem` checks.
 - The residential node economics model works for flat-rate fiber operators. Commercial cloud hosting is explicitly not viable at current pricing.
-- Fedimint federation custody (v1) runs 5 nodes operated by the protocol team. Concrete decentralisation timeline is a known gap.
+- Two-hop routing means every GB costs 2x bandwidth. At $5/250GB, nodes clear ~$0.008/GB each — viable for unmetered pipes, not cloud servers.
+- The hub cannot link buyers to sessions, but a compromised hub could potentially correlate timing. Future work: client-side node pairing from the Nostr relay index.
 
 ## Installation
 
@@ -240,29 +242,32 @@ Uses distroless base images for minimal attack surface. The hub image has zero s
 
 ```
 cmd/
-  arfl-hub/          Hub binary — discovery, payments, blind signing
-  arfl-node/         Node binary — WireGuard tunnels, token-gated /connect
+  arfl-hub/          Hub binary — discovery, payments, Cashu mint
+  arfl-node/         Node binary — WireGuard tunnels, Cashu-gated /cashu-connect
   arfl-client/       Client binary — purchase flow, tunnel management
 internal/
-  client/            Bandwidth SDK + TokenGate (node-side verifier)
+  client/            Bandwidth SDK + CashuConnector (node-side verifier)
   config/            JSON config loader for all components
-  control/           Node admin API (POST /connect, /peers, /quota)
-  credentials/       Blind signatures (RSA mint/verifier), HMAC tickets, key persistence
-  discovery/         Nostr-based node discovery + attestation
-  lightning/         Lightning client interface (LND REST adapter + mock)
-  nostr/             Nostr relay pool, keypairs, event handling
-  payments/          Purchase API, settlement engine, blind sig endpoints
+  control/           Node admin API (POST /cashu-connect, /peers, /quota)
+  credentials/       RSA blind signatures, HMAC tickets, key persistence
+  discovery/         Nostr-based node discovery + attestation + Cashu API
+  ecash/             Cashu ecash mint (BDHKE, NUT-01→07, worker pool)
+  lightning/         Lightning client interface (LND REST adapter + circuit breaker)
+  nostr/             Nostr relay pool, NIP-44 encryption, keypairs, events
+  payments/          Purchase API, settlement engine, node payouts
   quota/             Kernel-level bandwidth enforcement (nftables)
   routing/           IP forwarding + NAT setup
-  store/             SQLite storage (invoices, tickets, entitlements, spent tokens)
+  store/             SQLite storage (invoices, proofs, keysets, quotes, settlements)
   wg/                WireGuard interface management (wgctrl)
 pkg/
   protocol/          Protocol constants (MTU, ports, intervals)
   types/             Shared types (NodeInfo, NodeRole)
+test/
+  integration/       E2E tests (full Cashu privacy flow)
+  loadtest/          Performance load tests (/v1/redeem throughput)
 deployments/         systemd units, nftables rules, setup scripts
 deploy/              Docker Compose testnet (hub + nodes + relay)
-test/integration/    End-to-end integration tests
-.notes/              Architecture decisions (87 documented decisions)
+docs/                Architecture, API spec, deployment guide
 ```
 
 See [docs/architecture.md](./docs/architecture.md) for the nested WireGuard two-hop design, encryption layers, and routing rules.
@@ -310,16 +315,17 @@ Covers: purchase → pay → redeem → verify → spend → double-spend detect
 ```
  Client                          Hub                           Node
    │                              │                              │
-   │  POST /purchase {tier}       │                              │
+   │  POST /v1/mint/quote/bolt11  │                              │
+   │  {amount: 500, unit: "sat"}  │                              │
    │ ────────────────────────────►│                              │
    │  ◄─── Lightning invoice ─── │                              │
    │                              │                              │
    │  [pays invoice externally]   │                              │
    │                              │  settlement listener         │
-   │                              │  creates entitlement         │
+   │                              │  marks quote as PAID         │
    │                              │                              │
-   │  POST /redeem                │                              │
-   │  {preimage, blinded_msgs}    │                              │
+   │  POST /v1/mint/bolt11        │                              │
+   │  {quote, blinded_messages}   │                              │
    │ ────────────────────────────►│                              │
    │  ◄─── blind_signatures ──── │                              │
    │                              │                              │
@@ -327,14 +333,16 @@ Covers: purchase → pay → redeem → verify → spend → double-spend detect
    │   locally — Hub never        │                              │
    │   sees token secrets]        │                              │
    │                              │                              │
-   │  POST /connect               │                              │
-   │  {token, wg_pubkey}          │                              │
-   │ ─────────────────────────────────────────────────────────► │
-   │                              │  POST /spend {token}         │
-   │                              │ ◄──────────────────────────  │
-   │                              │  ──── first_spend: true ──► │
+   │  NIP-44 encrypted event      │                              │
+   │  {proofs, wg_pubkey, role}   │                              │
+   │ ─────────────────── via Nostr relay ──────────────────────►│
    │                              │                              │
-   │  ◄──── {tunnel_ip, pubkey, bytes_allowed} ──────────────── │
+   │                              │  POST /v1/redeem             │
+   │                              │  {proofs, node_pubkey}       │
+   │                              │ ◄──────────────────────────  │
+   │                              │  ── {ok, bytes_allowed} ──► │
+   │                              │                              │
+   │  ◄──── {tunnel_ip, pubkey, endpoint} ───────────────────── │
    │                              │                              │
    │  [WireGuard tunnel established]                             │
    │ ═══════════════ encrypted traffic ════════════════════════► │
@@ -373,15 +381,34 @@ go vet ./...
 - [x] **Phase 4** — Blind signatures (RSA mint, Chaumian tokens, STRIDE)
 - [x] **Phase 5** — Client integration (SDK, TokenGate, binary wiring)
 - [x] **Phase 6** — Token→connect flow, LND adapter, Docker testnet
-- [ ] **Phase 7** — Fedimint federation deposits
-- [ ] **Phase 8** — Mobile app (gomobile bindings)
-- [ ] **Phase 9** — Multi-hop routing (>2 hops)
+- [x] **Phase 9** — Client-side node selection + Cashu token redemption
+- [x] **Phase 10** — Node-side Cashu gate + hub redeemer
+- [x] **Phase 11** — NIP-44 encrypted token delivery via Nostr
+- [x] **Phase 12** — E2E integration test (full privacy chain)
+- [x] **Phase 13** — VPS deployment (3 servers, systemd)
+- [x] **Phase 14** — Performance engineering (benchmarks, pprof, load test, optimization)
+- [ ] **Phase 15** — LNbits extension (wallet integration)
+- [ ] **Phase 16** — Mobile app (gomobile bindings)
+- [ ] **Phase 17** — Multi-hop routing (>2 hops)
+
+## Performance
+
+Benchmarked on Apple M1 Pro (single core):
+
+| Operation | Throughput | Latency |
+|-----------|-----------|---------|
+| Token redeem (hub) | 15,000/sec | p50: 862µs |
+| VerifyProofs (single) | 6,000/sec | 167µs |
+| NIP-44 Encrypt | 360,000/sec | 2.8µs |
+| ECDH (per session) | 7,300/sec | 137µs |
 
 ## Links
 
 - [Whitepaper (PDF)](./ARFL_Whitepaper.pdf)
 - [Architecture](./docs/architecture.md)
-- [Decision Log](./.notes/decisions.md)
+- [API Specification](./docs/api-spec.md)
+- [Deployment Guide](./docs/deployment-guide.md)
+- [Releases](https://github.com/Radi-Labs/ARFL/releases)
 
 ## License
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,23 @@
+remote_theme: pages-themes/minimal@v0.2.0
+plugins:
+  - jekyll-remote-theme
+
+title: ARFL
+description: Privacy-respecting bandwidth marketplace powered by Bitcoin
+url: "https://radi-labs.github.io"
+baseurl: "/ARFL"
+
+exclude:
+  - cmd/
+  - internal/
+  - pkg/
+  - test/
+  - deploy/
+  - deployments/
+  - "*.go"
+  - go.mod
+  - go.sum
+  - Dockerfile
+  - CODEOWNERS
+  - arfl-hub
+  - arfl-node

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: API Specification
+---
+
 # ARFL Hub API Specification
 
 **Version:** 0.1.0  
@@ -347,5 +352,135 @@ MVP uses no authentication on public endpoints. Node identity is verified via:
 - Nostr event signatures (node announcements)
 - Hub-signed attestations (node authorization)
 - Schnorr signatures (usage reports)
+
+---
+
+## Cashu Ecash Mint (NUT-01 → NUT-07)
+
+The hub operates a Cashu-compatible ecash mint. These endpoints follow the [Cashu NUT specification](https://github.com/cashubtc/nuts).
+
+### GET /v1/keys
+
+Returns the mint's active public keys (NUT-01).
+
+**Response:**
+```json
+{
+  "keysets": [{
+    "id": "00eb7476a759a27e",
+    "unit": "sat",
+    "keys": {
+      "1": "02abc...",
+      "2": "03def...",
+      "4": "02fed..."
+    }
+  }]
+}
+```
+
+### GET /v1/keysets
+
+Returns all keysets with their status (NUT-02).
+
+**Response:**
+```json
+{
+  "keysets": [{
+    "id": "00eb7476a759a27e",
+    "unit": "sat",
+    "active": true,
+    "input_fee_ppk": 0
+  }]
+}
+```
+
+### POST /v1/mint/quote/bolt11
+
+Request a mint quote — returns a Lightning invoice to pay (NUT-04).
+
+**Request:**
+```json
+{
+  "amount": 64,
+  "unit": "sat"
+}
+```
+
+**Response:**
+```json
+{
+  "quote": "unique-quote-id",
+  "request": "lnbc640n1...",
+  "state": "UNPAID",
+  "expiry": 1784041000
+}
+```
+
+### POST /v1/mint/bolt11
+
+After paying the invoice, mint tokens by providing blinded messages (NUT-04).
+
+**Request:**
+```json
+{
+  "quote": "unique-quote-id",
+  "outputs": [
+    {"amount": 64, "id": "00eb7476a759a27e", "B_": "02..."}
+  ]
+}
+```
+
+**Response:**
+```json
+{
+  "signatures": [
+    {"amount": 64, "id": "00eb7476a759a27e", "C_": "03..."}
+  ]
+}
+```
+
+### POST /v1/swap
+
+Swap proofs for new blinded signatures (NUT-03). Used for splitting denominations.
+
+**Request:**
+```json
+{
+  "inputs": [{"amount": 64, "id": "...", "secret": "...", "C": "..."}],
+  "outputs": [{"amount": 32, "id": "...", "B_": "..."}, {"amount": 32, "id": "...", "B_": "..."}]
+}
+```
+
+### POST /v1/checkstate
+
+Check if proofs are spent (NUT-07).
+
+**Request:**
+```json
+{
+  "Ys": ["02abc...", "03def..."]
+}
+```
+
+### POST /v1/redeem
+
+ARFL-specific: Node presents proofs for bandwidth redemption.
+
+**Request:**
+```json
+{
+  "proofs": [{"amount": 64, "id": "00eb7476a759a27e", "secret": "...", "C": "..."}],
+  "node_pubkey": "node-nostr-pubkey-hex"
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "bytes_allowed": 64000000,
+  "sats_redeemed": 64
+}
+```
 
 Extension builders should verify node events client-side using the hub's Nostr pubkey.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,9 @@
-# ARFL Architecture — Phase 0 Spike
+---
+layout: default
+title: Architecture
+---
+
+# ARFL Architecture
 
 ## 1. Nested WireGuard Two-Hop Design
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Deployment Guide
+---
+
 # ARFL Deployment Guide
 
 Step-by-step guide to deploy a full ARFL network: hub, entry node, exit node, and Lightning payments.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,124 @@
+---
+layout: default
+title: Home
+---
+
+# ARFL
+
+**Privacy-respecting bandwidth marketplace powered by Bitcoin.**
+
+ARFL is a decentralised VPN protocol that combines WireGuard, Nostr, the Bitcoin Lightning Network, and Cashu ecash into a self-sustaining privacy network.
+
+**No accounts. No subscriptions. No logs.**
+
+---
+
+## How It Works
+
+```
+Client ──── Lightning ────► Hub (Cashu mint) ◄── Nostr ── Nodes
+  │                                                         │
+  └──── NIP-44 encrypted token ─── WireGuard tunnel ──────►│
+```
+
+1. Pay a Lightning invoice for bandwidth
+2. Receive Cashu ecash tokens (blind-signed, unlinkable)
+3. Deliver tokens to a node via encrypted Nostr event
+4. Node verifies → grants WireGuard access
+5. Traffic routes through a nested two-hop tunnel
+
+---
+
+## Privacy Guarantees
+
+| Property | Mechanism |
+|----------|-----------|
+| Buyer-session unlinkability | Cashu BDHKE blind signatures |
+| Token delivery privacy | NIP-44 end-to-end encryption |
+| Entry can't see destinations | Nested WireGuard (inner tunnel) |
+| Exit can't see client IP | Only sees entry node's NAT IP |
+| No identity required | Lightning = no personal info |
+
+---
+
+## Performance
+
+Benchmarked on a single CPU core:
+
+| Operation | Throughput |
+|-----------|-----------|
+| Token redeem | **15,000/sec** |
+| Proof verification | **6,000/sec** |
+| NIP-44 encrypt/decrypt | **360,000/sec** |
+
+---
+
+## Quick Start
+
+### Download
+
+Get the latest binaries from [Releases](https://github.com/Radi-Labs/ARFL/releases/latest).
+
+```bash
+# Verify checksums
+sha256sum -c checksums.txt
+
+# Run hub
+./arfl-hub-linux-amd64 --config hub.json
+
+# Run node
+./arfl-node-linux-amd64 --config node.json
+```
+
+### Build from Source
+
+```bash
+git clone https://github.com/Radi-Labs/ARFL.git
+cd ARFL
+go build ./...
+```
+
+---
+
+## Documentation
+
+- [Architecture](./architecture) — Nested WireGuard two-hop design
+- [API Specification](./api-spec) — Hub HTTP endpoints (NUT-01→07, discovery, payments)
+- [Deployment Guide](./deployment-guide) — Production setup on VPS
+
+---
+
+## Technology Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Transport | WireGuard (nested two-hop) |
+| Discovery | Nostr relays (kind 30078) |
+| Payments | Bitcoin Lightning Network |
+| Privacy | Cashu ecash (BDHKE) |
+| Token delivery | NIP-44 encryption |
+| Storage | SQLite |
+| Language | Go |
+
+---
+
+## Economics
+
+- Users pay per-GB via Lightning (~500 sats/GB)
+- Node operators earn passive income on bandwidth they already own
+- Hub takes a configurable margin (default 20%)
+- Designed for residential/unmetered connections — not cloud servers
+
+---
+
+## Links
+
+- [GitHub Repository](https://github.com/Radi-Labs/ARFL)
+- [Releases](https://github.com/Radi-Labs/ARFL/releases)
+- [Whitepaper (PDF)](https://github.com/Radi-Labs/ARFL/blob/main/ARFL_Whitepaper.pdf)
+
+---
+
+## License
+
+[MIT](https://github.com/Radi-Labs/ARFL/blob/main/LICENSE) — Radi Labs


### PR DESCRIPTION
## Summary

Updates all documentation to reflect the current Cashu-based protocol and creates a GitHub Pages site.

### README Updates
- Positioning: "privacy-respecting bandwidth marketplace" (not "untraceable VPN")
- Protocol now shows Cashu BDHKE + NIP-44 delivery (replaces RSA blind sigs)
- Updated architecture tree (ecash package, loadtest, nostr/NIP-44)
- Added Performance section with benchmark numbers
- Updated Roadmap through Phase 14
- Added release badge

### GitHub Pages
- Landing page at `docs/index.md` — clean, scannable overview
- Deploys automatically on docs/ changes via `.github/workflows/pages.yml`
- Uses Jekyll minimal theme
- All existing docs (architecture, api-spec, deployment-guide) render as pages

### API Spec Updates
- Added complete Cashu NUT-01→07 endpoint documentation
- Added `/v1/redeem` (ARFL-specific node redemption)

### After Merge
1. Enable GitHub Pages in repo Settings → Pages → Source: GitHub Actions
2. Site will be live at: https://radi-labs.github.io/ARFL/