### PR TITLE
fix: resolve race condition in circuit breaker probe goroutine

### DIFF
--- a/internal/lightning/circuit_breaker.go
+++ b/internal/lightning/circuit_breaker.go
@@ -232,14 +232,16 @@ func (cb *CircuitBreaker) recordResult(err error) {
 }
 
 // startProbe launches the background self-remediation goroutine.
+// Must be called with cb.mu held.
 func (cb *CircuitBreaker) startProbe() {
 	cb.probeOnce.Do(func() {
-		go cb.probeLoop()
+		stopCh := cb.stopProbe
+		go cb.probeLoop(stopCh)
 	})
 }
 
 // probeLoop periodically tests LND connectivity when circuit is open.
-func (cb *CircuitBreaker) probeLoop() {
+func (cb *CircuitBreaker) probeLoop(stopCh <-chan struct{}) {
 	ticker := time.NewTicker(cb.config.ProbeInterval)
 	defer ticker.Stop()
 
@@ -247,7 +249,7 @@ func (cb *CircuitBreaker) probeLoop() {
 
 	for {
 		select {
-		case <-cb.stopProbe:
+		case <-stopCh:
 			log.Printf("[circuit-breaker] probe stopped — circuit recovered")
 			return
 		case <-ticker.C:
@@ -279,18 +281,24 @@ func (cb *CircuitBreaker) probeLoop() {
 }
 
 // stopProbing signals the probe goroutine to stop.
+// Must be called with cb.mu held.
 func (cb *CircuitBreaker) stopProbing() {
+	ch := cb.stopProbe
+
 	select {
-	case cb.stopProbe <- struct{}{}:
+	case ch <- struct{}{}:
 	default:
 	}
-	// Reset probeOnce so future opens can start a new probe
+
+	// Reset probeOnce so future opens can start a new probe.
 	cb.probeOnce = sync.Once{}
 	cb.stopProbe = make(chan struct{})
 }
 
 // Stop gracefully shuts down the circuit breaker.
 func (cb *CircuitBreaker) Stop() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
 	cb.stopProbing()
 }
 


### PR DESCRIPTION
## Problem

CI was failing on `internal/lightning` — all individual tests passed (`--- PASS`) but the package reported `FAIL`. The race detector caught unsynchronized access to `cb.stopProbe` channel between:
- `stopProbing()` reassigning the channel
- `probeLoop()` reading from it in a `select`

## Fix

- Capture the `stopProbe` channel reference under `cb.mu` before launching the goroutine
- Pass it as a parameter to `probeLoop(stopCh)` so the goroutine never reads the struct field directly
- `Stop()` now acquires `cb.mu` before calling `stopProbing()` (which assumes lock is held, matching `recordResult`'s usage)

## Verification

```
go test -race -count=5 ./internal/lightning/  → PASS (7.8s)
go test -race -count=1 ./...                  → all packages PASS
```