### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,16 @@ Benchmarked on Apple M1 Pro (single core):
 - [Deployment Guide](./docs/deployment-guide.md)
 - [Releases](https://github.com/Radi-Labs/ARFL/releases)
 
+## Responsible Use
+
+ARFL is experimental open-source networking software intended for legitimate
+privacy, networking, and bandwidth-sharing use cases.
+
+ARFL is provided as open-source software and may be independently operated,
+modified, and deployed by third parties. Users and operators are responsible
+for complying with the laws and regulations applicable to their use of the
+software and infrastructure.
+
 ## License
 
 [MIT](./LICENSE) — Radi Labs


### PR DESCRIPTION
# Add responsible use guidance to README

## Summary

Adds a short Responsible Use section to the README clarifying the intended use of ARFL and the responsibilities of users and independent operators.

## Changes

* Clarifies that ARFL is experimental open-source networking software.
* States that the project is intended for legitimate privacy, networking, and bandwidth-sharing use cases.
* Clarifies that ARFL can be independently operated, modified, and deployed by third parties.
* Notes that users and operators are responsible for complying with applicable laws and regulations.

## Motivation

ARFL is designed as open-source networking infrastructure that can be independently deployed and operated. This section provides clear context around the project's intended use without making assumptions about how third parties may deploy the software.

No functional or architectural changes are introduced.
