### PR TITLE
fix: route through OS-assigned interfaces, present proofs to the right gate, and close two check-then-act races

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,11 @@ target
 #.idea/
 .DS_Store
 
-# Binaries
-arfl-hub
-arfl-node
-arfl-client
+# Binaries (anchored to the repo root: unanchored names also matched the
+# cmd/arfl-* source directories, which silently ignored new files added there)
+/arfl-hub
+/arfl-node
+/arfl-client
 
 # Config files (may contain secrets)
 hub.json
@@ -34,4 +35,4 @@ keys/
 
 # Testnet generated data
 deploy/data/
-arfl-hub-linux
+/arfl-hub-linux

--- a/cmd/arfl-client/main.go
+++ b/cmd/arfl-client/main.go
@@ -216,10 +216,20 @@ func main() {
 	}
 	log.Println("[client] outer tunnel configured")
 
+	// The OS may not use the name we asked for — macOS assigns utunN — so
+	// routes must use the name it actually assigned. Resolved after the
+	// interface exists; resolving earlier would silently return the logical
+	// name and point the routes at nothing.
+	outerIf := wgMgr.InterfaceName("wg-outer")
+
+	teardown := func() {
+		cleanup(wgMgr, entryIP, exitIP, defaultGW, defaultIface)
+	}
+
 	// 2. Set up routing so exit node's IP goes through outer tunnel
 	log.Println("[client] configuring routes...")
-	addRoute(entryIP+"/32", defaultGW, defaultIface) // entry reachable via real gateway
-	addRoute(exitIP+"/32", "", "wg-outer")           // exit goes through outer tunnel
+	mustRoute(teardown, entryIP+"/32", defaultGW, defaultIface) // entry via real gateway
+	mustRoute(teardown, exitIP+"/32", "", outerIf)              // exit via outer tunnel
 
 	// 3. Create inner tunnel (client <-> exit node, carried inside outer)
 	log.Println("[client] creating inner tunnel to exit node...")
@@ -244,9 +254,11 @@ func main() {
 	}
 	log.Println("[client] inner tunnel configured")
 
+	innerIf := wgMgr.InterfaceName("wg-inner")
+
 	// 4. Route all traffic through inner tunnel
-	addRoute("0.0.0.0/1", "", "wg-inner")
-	addRoute("128.0.0.0/1", "", "wg-inner")
+	mustRoute(teardown, "0.0.0.0/1", "", innerIf)
+	mustRoute(teardown, "128.0.0.0/1", "", innerIf)
 
 	// 5. Set DNS to Quad9 within tunnel
 	setDNS(protocol.DNSResolver)
@@ -284,13 +296,18 @@ func main() {
 }
 
 func cleanup(wgMgr *wg.WgctrlManager, entryIP, exitIP, defaultGW, defaultIface string) {
-	// Remove routes
-	delRoute("0.0.0.0/1", "", "wg-inner")
-	delRoute("128.0.0.0/1", "", "wg-inner")
-	delRoute(exitIP+"/32", "", "wg-outer")
+	// Resolve before deleting the interfaces, since deleting drops the mapping.
+	outerIf := wgMgr.InterfaceName("wg-outer")
+	innerIf := wgMgr.InterfaceName("wg-inner")
+
+	// Every step is attempted even if an earlier one fails. Stopping early
+	// would leave the machine with tunnel routes or DNS still in place and no
+	// tunnel behind them.
+	delRoute("0.0.0.0/1", "", innerIf)
+	delRoute("128.0.0.0/1", "", innerIf)
+	delRoute(exitIP+"/32", "", outerIf)
 	delRoute(entryIP+"/32", defaultGW, defaultIface)
 
-	// Remove interfaces
 	wgMgr.DeleteInterface("wg-inner")
 	wgMgr.DeleteInterface("wg-outer")
 
@@ -359,7 +376,7 @@ func getDefaultGateway() (gw string, iface string) {
 	return gw, iface
 }
 
-func addRoute(cidr, gateway, iface string) {
+func addRoute(cidr, gateway, iface string) error {
 	var err error
 	switch runtime.GOOS {
 	case "linux":
@@ -384,7 +401,24 @@ func addRoute(cidr, gateway, iface string) {
 		}
 	}
 	if err != nil {
-		log.Printf("[route] add %s: %v", cidr, err)
+		return fmt.Errorf("add route %s dev %s: %w", cidr, iface, err)
+	}
+	return nil
+}
+
+// mustRoute adds a route or aborts the connection.
+//
+// A failed route used to be logged and ignored, which meant the client could
+// report a successful connection while traffic kept using the normal
+// interface — the tunnels were up but nothing was directed into them. For a
+// tool whose entire purpose is not leaking traffic, failing loudly is the only
+// safe behaviour, so this tears the connection down and exits.
+func mustRoute(teardown func(), cidr, gateway, iface string) {
+	if err := addRoute(cidr, gateway, iface); err != nil {
+		log.Printf("[client] %v", err)
+		log.Println("[client] refusing to continue: traffic would leave unprotected")
+		teardown()
+		os.Exit(1)
 	}
 }
 

--- a/cmd/arfl-desktop/frontend/tsconfig.json
+++ b/cmd/arfl-desktop/frontend/tsconfig.json
@@ -5,7 +5,6 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "resolveJsonModule": true,
-    "baseUrl": ".",
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.
      * Disable checkJs if you'd like to use dynamic types in JS.

--- a/cmd/arfl-desktop/frontend/vite.config.ts
+++ b/cmd/arfl-desktop/frontend/vite.config.ts
@@ -1,6 +1,15 @@
 import {defineConfig} from 'vite'
 import {svelte} from '@sveltejs/vite-plugin-svelte'
 
+// Everything in public/ is copied verbatim into dist/ on each build.
+//
+// That is what keeps public/.gitkeep alive. main.go embeds the built frontend
+// with `//go:embed all:frontend/dist`, which fails to compile if the directory
+// does not exist, so a fresh clone needs a committed file inside it. Vite
+// empties dist/ before every build, which used to delete that file and break
+// the Go build for anyone cloning afterwards. Sourcing it from public/ means
+// each build restores it rather than removing it.
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()]

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -134,7 +134,11 @@ func (n *testNode) connectCount() int {
 }
 
 func (n *testNode) handleConnect(w http.ResponseWriter, r *http.Request) {
-	if !strings.HasSuffix(r.URL.Path, "/connect") {
+	// Matched exactly. This used to be HasSuffix(path, "/connect"), which also
+	// matches "/cashu-connect" — so the fake accepted the client posting Cashu
+	// proofs to the RSA endpoint, and the mismatch survived until a real node
+	// rejected it. The fake must be as strict as the node it stands in for.
+	if r.URL.Path != "/cashu-connect" {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/client/cashu_connector.go
+++ b/internal/client/cashu_connector.go
@@ -39,7 +39,7 @@ func NewCashuConnector() *CashuConnector {
 	}
 }
 
-// CashuConnectRequest is sent to the node's /connect endpoint.
+// CashuConnectRequest is sent to the node's /cashu-connect endpoint.
 type CashuConnectRequest struct {
 	Proofs   cashu.Proofs `json:"proofs"`
 	WGPubkey string       `json:"wg_pubkey"`
@@ -72,7 +72,11 @@ func (cc *CashuConnector) ConnectWithProofs(
 		return nil, fmt.Errorf("marshal connect request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, connectURL+"/connect", bytes.NewReader(reqBody))
+	// The node serves two gates on this port: /connect takes the legacy RSA
+	// blind tokens, /cashu-connect takes Cashu proofs. Posting proofs to
+	// /connect decodes into an empty token and is rejected, so the path must
+	// match the credential being presented.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, connectURL+"/cashu-connect", bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}

--- a/internal/client/cashu_connector_test.go
+++ b/internal/client/cashu_connector_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elnosh/gonuts/cashu"
+)
+
+// TestCashuConnectorTargetsTheCashuGate pins the endpoint the connector calls.
+//
+// The node exposes two gates on the same port: /connect for the legacy RSA
+// blind tokens and /cashu-connect for Cashu proofs. The connector posted to
+// /connect, so proofs were decoded as an empty RSA token and every real
+// connection attempt failed. Nothing caught it, because the mocks in the unit
+// tests answered whatever path the connector asked for and the E2E test built
+// the /cashu-connect URL by hand instead of going through the connector.
+//
+// This registers the two paths the way the node does and asserts which one is
+// reached, so the routing is verified rather than assumed.
+func TestCashuConnectorTargetsTheCashuGate(t *testing.T) {
+	var gotPath string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /connect", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		http.Error(w, "RSA gate: token required", http.StatusBadRequest)
+	})
+	mux.HandleFunc("POST /cashu-connect", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+
+		var req CashuConnectRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if len(req.Proofs) == 0 {
+			t.Error("cashu gate received no proofs")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":         "connected",
+			"tunnel_ip":      "10.100.0.5/32",
+			"node_wg_pubkey": "bm9kZXB1YmtleWJhc2U2NGVuY29kZWQxMjM0NTY3OD0=",
+			"bytes_allowed":  1048576,
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cc := NewCashuConnector()
+	proofs := cashu.Proofs{{
+		Amount: 32,
+		Id:     "00ad268c4d1f5826",
+		Secret: "deadbeef",
+		C:      "02abcdef",
+	}}
+
+	resp, err := cc.ConnectWithProofs(context.Background(), srv.URL, proofs, "Y2xpZW50cHVia2V5YmFzZTY0ZW5jb2RlZDEyMzQ1Njc4PQ==")
+	if err != nil {
+		t.Fatalf("ConnectWithProofs: %v", err)
+	}
+
+	if gotPath != "/cashu-connect" {
+		t.Errorf("connector posted proofs to %q, want /cashu-connect; the RSA gate cannot read Cashu proofs", gotPath)
+	}
+	if resp.TunnelIP != "10.100.0.5/32" {
+		t.Errorf("tunnel IP = %q, want 10.100.0.5/32", resp.TunnelIP)
+	}
+}
+
+// TestCashuConnectorReportsGateErrors checks a rejection from the node is
+// surfaced with its status and body, so a misrouted or refused connection is
+// diagnosable rather than a bare failure.
+func TestCashuConnectorReportsGateErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "proof already spent", http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	cc := NewCashuConnector()
+	proofs := cashu.Proofs{{Amount: 32, Id: "00ad268c4d1f5826", Secret: "s", C: "02ab"}}
+
+	_, err := cc.ConnectWithProofs(context.Background(), srv.URL, proofs, "cHVia2V5")
+	if err == nil {
+		t.Fatal("expected an error when the node rejects the proofs")
+	}
+	if !strings.Contains(err.Error(), "409") || !strings.Contains(err.Error(), "already spent") {
+		t.Errorf("error %q should carry the status and the node's reason", err)
+	}
+}

--- a/internal/client/selector_test.go
+++ b/internal/client/selector_test.go
@@ -175,9 +175,11 @@ func TestSelectPair_IntegrationWithMockHub(t *testing.T) {
 // --- CashuConnector tests ---
 
 func TestCashuConnector_HappyPath(t *testing.T) {
-	// Mock node /connect endpoint.
+	// Mock the node's /cashu-connect endpoint. The path is asserted exactly:
+	// posting proofs to /connect reaches the RSA gate, which decodes them into
+	// an empty token and rejects the request.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/connect" || r.Method != http.MethodPost {
+		if r.URL.Path != "/cashu-connect" || r.Method != http.MethodPost {
 			http.NotFound(w, r)
 			return
 		}

--- a/internal/discovery/cashu_api.go
+++ b/internal/discovery/cashu_api.go
@@ -394,14 +394,17 @@ func (api *DiscoveryAPI) handleSwap(w http.ResponseWriter, r *http.Request) {
 
 	sigs, err := api.cryptoPool.Swap(ctx, req.Inputs, req.Outputs)
 	if err != nil {
-		switch err {
-		case ecash.ErrInvalidProof:
+		// errors.Is, not equality: a duplicate detected by the store is
+		// wrapped on the way out, and an exact match would report the
+		// conflict as a 500 the client would retry forever.
+		switch {
+		case errors.Is(err, ecash.ErrInvalidProof):
 			writeError(w, http.StatusBadRequest, err.Error())
-		case ecash.ErrProofAlreadySpent:
-			writeError(w, http.StatusConflict, err.Error())
-		case ecash.ErrDuplicateProofs:
+		case errors.Is(err, ecash.ErrProofAlreadySpent):
+			writeError(w, http.StatusConflict, "proof already spent")
+		case errors.Is(err, ecash.ErrDuplicateProofs):
 			writeError(w, http.StatusBadRequest, err.Error())
-		case ecash.ErrAmountMismatch:
+		case errors.Is(err, ecash.ErrAmountMismatch):
 			writeError(w, http.StatusBadRequest, err.Error())
 		default:
 			log.Printf("[ecash] swap error: %v", err)

--- a/internal/ecash/doublespend_test.go
+++ b/internal/ecash/doublespend_test.go
@@ -25,7 +25,11 @@ type racyStore struct {
 	mu      sync.Mutex
 	spent   map[string]bool
 	readGap time.Duration
-	reads   int
+
+	// active/peak track how many reads overlap, so concurrency can be
+	// asserted directly instead of inferred from elapsed time.
+	active int
+	peak   int
 }
 
 func newRacyStore() *racyStore {
@@ -42,11 +46,26 @@ func newRacyStore() *racyStore {
 func (s *racyStore) IsProofSpent(y string) (bool, error) {
 	s.mu.Lock()
 	was := s.spent[y]
-	s.reads++
+	s.active++
+	if s.active > s.peak {
+		s.peak = s.active
+	}
 	s.mu.Unlock()
 
 	time.Sleep(s.readGap)
+
+	s.mu.Lock()
+	s.active--
+	s.mu.Unlock()
 	return was, nil
+}
+
+// peakReaders reports the greatest number of reads that were ever in flight
+// at the same time.
+func (s *racyStore) peakReaders() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.peak
 }
 
 // SaveSpentProofs deliberately overwrites without complaint, so acceptance is
@@ -64,6 +83,42 @@ func (s *racyStore) GetSpentProofsCount() (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return int64(len(s.spent)), nil
+}
+
+// GetMintQuote stalls after reading, so concurrent callers all observe the same
+// state and any check-then-act on it is exposed.
+func (s *racyStore) GetMintQuote(id string) (*MintQuote, error) {
+	s.mu.Lock()
+	q, ok := s.quotes[id]
+	if !ok {
+		s.mu.Unlock()
+		return nil, ErrQuoteNotFound
+	}
+	// Copy under the lock. Reading the fields after releasing it would race
+	// with a concurrent transition writing them.
+	copied := *q
+	s.mu.Unlock()
+
+	time.Sleep(s.readGap)
+	return &copied, nil
+}
+
+// TransitionMintQuoteState compares and sets atomically, as the contract on
+// ecash.Store requires. The race must be settled by the mint using this, not by
+// the store being lucky.
+func (s *racyStore) TransitionMintQuoteState(id string, from, to QuoteState) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	q, ok := s.quotes[id]
+	if !ok {
+		return false, ErrQuoteNotFound
+	}
+	if q.State != from {
+		return false, nil
+	}
+	q.State = to
+	return true, nil
 }
 
 // spendRace fires n concurrent attempts to spend the same proof, released
@@ -178,9 +233,63 @@ func TestSwapIsAtomic(t *testing.T) {
 	}
 }
 
+// TestMintTokensIssuesOncePerQuote is the regression test for quote
+// double-issuance: MintTokens used to read the quote state, sign, and only
+// then mark it issued, so two concurrent requests for one paid invoice both
+// saw QuotePaid and both received signatures — one Lightning payment, two sets
+// of tokens.
+//
+// The store stalls inside the quote read, so without an atomic claim every
+// caller is guaranteed to observe QuotePaid. Exactly one may be served.
+func TestMintTokensIssuesOncePerQuote(t *testing.T) {
+	store := newRacyStore()
+	m, err := NewMint(store, testSeed)
+	if err != nil {
+		t.Fatalf("new mint: %v", err)
+	}
+
+	const quoteID = "quote-race"
+	store.quotes[quoteID] = &MintQuote{
+		ID:     quoteID,
+		Amount: 8,
+		State:  QuotePaid,
+	}
+
+	const attempts = 8
+	accepted, errs := spendRace(t, attempts, func() error {
+		outputs, err := blindedOutputs(m, 8)
+		if err != nil {
+			return err
+		}
+		_, err = m.MintTokens(quoteID, outputs)
+		return err
+	})
+
+	if accepted != 1 {
+		t.Fatalf("one paid quote issued tokens %d times out of %d concurrent attempts, want exactly 1: the mint gave away %d free token sets", accepted, attempts, accepted-1)
+	}
+	for _, err := range errs {
+		if !errors.Is(err, ErrQuoteAlreadyUsed) {
+			t.Errorf("losing attempt failed with %v, want ErrQuoteAlreadyUsed", err)
+		}
+	}
+
+	q, err := store.GetMintQuote(quoteID)
+	if err != nil {
+		t.Fatalf("get quote: %v", err)
+	}
+	if q.State != QuoteIssued {
+		t.Errorf("quote state = %v, want %v", q.State, QuoteIssued)
+	}
+}
+
 // TestVerifyProofsStillAllowsConcurrentReads guards against fixing the race by
 // serialising all verification: checking proofs without spending them (the
 // /v1/checkstate path) must not queue behind other callers' spends.
+//
+// Concurrency is measured directly rather than by elapsed time. A wall-clock
+// bound would flake on a loaded CI runner under -race, and would only show
+// overlap indirectly.
 func TestVerifyProofsStillAllowsConcurrentReads(t *testing.T) {
 	store := newRacyStore()
 	m, err := NewMint(store, testSeed)
@@ -194,7 +303,6 @@ func TestVerifyProofsStillAllowsConcurrentReads(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(readers)
 
-	began := time.Now()
 	for i := 0; i < readers; i++ {
 		go func() {
 			defer wg.Done()
@@ -205,10 +313,7 @@ func TestVerifyProofsStillAllowsConcurrentReads(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Serialised, this would take readers × readGap. Allow generous slack for
-	// slow CI while still failing if the reads were queued.
-	if limit := time.Duration(readers) * store.readGap; time.Since(began) >= limit {
-		t.Errorf("%d concurrent verifications took %v, at least the %v a fully serialised path would need: read-only checks are being blocked",
-			readers, time.Since(began), limit)
+	if peak := store.peakReaders(); peak < 2 {
+		t.Errorf("peak concurrent verifications was %d of %d readers: read-only checks are being serialised", peak, readers)
 	}
 }

--- a/internal/ecash/mint.go
+++ b/internal/ecash/mint.go
@@ -459,10 +459,22 @@ func (m *Mint) MintTokens(quoteID string, outputs cashu.BlindedMessages) (cashu.
 	// Sign the blinded messages
 	sigs, err := m.SignBlindedMessages(outputs)
 	if err != nil {
-		// The quote is spent but produced nothing. Hand it back so the payer
+		// The quote is claimed but produced nothing. Hand it back so the payer
 		// can retry rather than losing the payment to a transient failure.
-		if _, rerr := m.store.TransitionMintQuoteState(quoteID, QuoteIssued, QuotePaid); rerr != nil {
+		//
+		// The release is itself conditional, so it can legitimately lose: if
+		// the quote is no longer QuoteIssued something else has moved it, and
+		// silently discarding that would leave a paid quote stuck in a state
+		// no retry can recover from while reporting only the signing error.
+		// Both cases are surfaced, because a payment that produced no tokens
+		// and cannot be retried is not something an operator should have to
+		// infer from a missing log line.
+		released, rerr := m.store.TransitionMintQuoteState(quoteID, QuoteIssued, QuotePaid)
+		if rerr != nil {
 			return nil, fmt.Errorf("signing failed (%v) and quote %s could not be released: %w", err, quoteID, rerr)
+		}
+		if !released {
+			return nil, fmt.Errorf("signing failed (%v) and quote %s was not released: it is no longer in the issued state", err, quoteID)
 		}
 		return nil, err
 	}

--- a/internal/ecash/mint.go
+++ b/internal/ecash/mint.go
@@ -80,6 +80,12 @@ type Store interface {
 	GetMintQuote(id string) (*MintQuote, error)
 	UpdateMintQuoteState(id string, state QuoteState) error
 
+	// TransitionMintQuoteState must compare and set atomically, reporting
+	// false if the quote was not in the expected state. Claiming a quote is
+	// the moment a payment becomes tokens, so a caller that reads the state
+	// and writes it back separately can issue twice for one payment.
+	TransitionMintQuoteState(id string, from, to QuoteState) (bool, error)
+
 	// Spent proofs
 	//
 	// SaveSpentProofs must be atomic across all proofs in the batch and must
@@ -434,15 +440,31 @@ func (m *Mint) MintTokens(quoteID string, outputs cashu.BlindedMessages) (cashu.
 		return nil, ErrOutputOverQuote
 	}
 
+	// Claim the quote before signing anything.
+	//
+	// Checking the state and then marking it issued afterwards is the same
+	// check-then-act hole that allowed proofs to be double spent: two requests
+	// carrying one paid quote both read QuotePaid, both sign, and a single
+	// Lightning payment becomes two sets of tokens. The transition is a
+	// conditional update, so exactly one caller can move the quote out of
+	// QuotePaid and the loser is turned away here, before any signature exists.
+	won, err := m.store.TransitionMintQuoteState(quoteID, QuotePaid, QuoteIssued)
+	if err != nil {
+		return nil, fmt.Errorf("claiming quote: %w", err)
+	}
+	if !won {
+		return nil, ErrQuoteAlreadyUsed
+	}
+
 	// Sign the blinded messages
 	sigs, err := m.SignBlindedMessages(outputs)
 	if err != nil {
+		// The quote is spent but produced nothing. Hand it back so the payer
+		// can retry rather than losing the payment to a transient failure.
+		if _, rerr := m.store.TransitionMintQuoteState(quoteID, QuoteIssued, QuotePaid); rerr != nil {
+			return nil, fmt.Errorf("signing failed (%v) and quote %s could not be released: %w", err, quoteID, rerr)
+		}
 		return nil, err
-	}
-
-	// Mark quote as issued
-	if err := m.store.UpdateMintQuoteState(quoteID, QuoteIssued); err != nil {
-		return nil, fmt.Errorf("updating quote state: %w", err)
 	}
 
 	return sigs, nil

--- a/internal/ecash/mint_test.go
+++ b/internal/ecash/mint_test.go
@@ -2,6 +2,7 @@ package ecash
 
 import (
 	"encoding/hex"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,10 @@ type memStore struct {
 	keysets     map[string]*KeysetRecord
 	quotes      map[string]*MintQuote
 	spentProofs map[string]bool
+
+	// quoteMu guards the compare-and-set in TransitionMintQuoteState, which
+	// concurrency tests rely on to pick a single winner.
+	quoteMu sync.Mutex
 }
 
 func newMemStore() *memStore {
@@ -75,6 +80,23 @@ func (s *memStore) UpdateMintQuoteState(id string, state QuoteState) error {
 	}
 	q.State = state
 	return nil
+}
+
+// TransitionMintQuoteState compares and sets under the store's own lock, so
+// only one caller can move a quote out of a given state.
+func (s *memStore) TransitionMintQuoteState(id string, from, to QuoteState) (bool, error) {
+	s.quoteMu.Lock()
+	defer s.quoteMu.Unlock()
+
+	q, ok := s.quotes[id]
+	if !ok {
+		return false, ErrQuoteNotFound
+	}
+	if q.State != from {
+		return false, nil
+	}
+	q.State = to
+	return true, nil
 }
 
 func (s *memStore) SaveSpentProofs(proofs []SpentProof) error {

--- a/internal/ecash/mint_test.go
+++ b/internal/ecash/mint_test.go
@@ -2,6 +2,7 @@ package ecash
 
 import (
 	"encoding/hex"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -499,5 +500,98 @@ func TestDuplicateProofs(t *testing.T) {
 	_, err := m.VerifyProofs(cashu.Proofs{proof, proof})
 	if err != ErrDuplicateProofs {
 		t.Fatalf("expected ErrDuplicateProofs, got: %v", err)
+	}
+}
+
+// unreleasableStore lets a quote be claimed but refuses to hand it back,
+// standing in for the case where something else has already moved the quote
+// out of QuoteIssued by the time signing fails.
+type unreleasableStore struct {
+	*memStore
+}
+
+func (s *unreleasableStore) TransitionMintQuoteState(id string, from, to QuoteState) (bool, error) {
+	if from == QuoteIssued && to == QuotePaid {
+		return false, nil
+	}
+	return s.memStore.TransitionMintQuoteState(id, from, to)
+}
+
+// unsignableOutputs reference a keyset the mint does not hold, so signing
+// fails after the quote has already been claimed.
+func unsignableOutputs(t *testing.T) cashu.BlindedMessages {
+	t.Helper()
+
+	r, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	B_, _, err := gcrypto.BlindMessage(hex.EncodeToString(r.Serialize()[:16]), r)
+	if err != nil {
+		t.Fatalf("blind: %v", err)
+	}
+	return cashu.BlindedMessages{cashu.NewBlindedMessage("0000000000000000", 8, B_)}
+}
+
+// TestMintTokensReleasesQuoteWhenSigningFails covers the other half of the
+// claim-before-sign change: claiming early means a signing failure would
+// otherwise burn a paid invoice that produced nothing. The quote must go back
+// to QuotePaid so the payer can retry.
+func TestMintTokensReleasesQuoteWhenSigningFails(t *testing.T) {
+	store := newMemStore()
+	m, err := NewMint(store, testSeed)
+	if err != nil {
+		t.Fatalf("NewMint: %v", err)
+	}
+
+	const quoteID = "quote-release"
+	store.quotes[quoteID] = &MintQuote{ID: quoteID, Amount: 8, State: QuotePaid}
+
+	if _, err := m.MintTokens(quoteID, unsignableOutputs(t)); err == nil {
+		t.Fatal("MintTokens succeeded with an unknown keyset, want a signing error")
+	}
+
+	q, err := store.GetMintQuote(quoteID)
+	if err != nil {
+		t.Fatalf("get quote: %v", err)
+	}
+	if q.State != QuotePaid {
+		t.Fatalf("quote state = %v after a failed signing, want %v: the payment was consumed without producing tokens", q.State, QuotePaid)
+	}
+
+	// The retry is the point of releasing it, so prove it actually works.
+	outputs, err := blindedOutputs(m, 8)
+	if err != nil {
+		t.Fatalf("blinded outputs: %v", err)
+	}
+	if _, err := m.MintTokens(quoteID, outputs); err != nil {
+		t.Fatalf("retry after a released quote failed: %v", err)
+	}
+}
+
+// TestMintTokensReportsAFailedRelease guards the case the PR review caught:
+// the release is itself conditional and can lose. Discarding that result would
+// leave a paid quote stranded in QuoteIssued while reporting only the signing
+// error, so an operator would have no way to tell a retryable failure from a
+// payment that can never be recovered.
+func TestMintTokensReportsAFailedRelease(t *testing.T) {
+	store := &unreleasableStore{memStore: newMemStore()}
+	m, err := NewMint(store, testSeed)
+	if err != nil {
+		t.Fatalf("NewMint: %v", err)
+	}
+
+	const quoteID = "quote-stuck"
+	store.quotes[quoteID] = &MintQuote{ID: quoteID, Amount: 8, State: QuotePaid}
+
+	_, err = m.MintTokens(quoteID, unsignableOutputs(t))
+	if err == nil {
+		t.Fatal("MintTokens succeeded, want an error")
+	}
+	if !strings.Contains(err.Error(), "not released") {
+		t.Errorf("error = %q, want it to report that the quote was not released", err)
+	}
+	if !strings.Contains(err.Error(), quoteID) {
+		t.Errorf("error = %q, want it to name the stranded quote %s", err, quoteID)
 	}
 }

--- a/internal/store/ecash_repository.go
+++ b/internal/store/ecash_repository.go
@@ -88,7 +88,6 @@ func (s *Store) GetMintQuote(id string) (*ecash.MintQuote, error) {
 	return &q, nil
 }
 
-// UpdateMintQuoteState transitions a mint quote to a new state.
 // UpdateMintQuoteState sets a quote's state unconditionally.
 //
 // Prefer TransitionMintQuoteState for the paid-to-issued step: this cannot

--- a/internal/store/ecash_repository.go
+++ b/internal/store/ecash_repository.go
@@ -89,6 +89,11 @@ func (s *Store) GetMintQuote(id string) (*ecash.MintQuote, error) {
 }
 
 // UpdateMintQuoteState transitions a mint quote to a new state.
+// UpdateMintQuoteState sets a quote's state unconditionally.
+//
+// Prefer TransitionMintQuoteState for the paid-to-issued step: this cannot
+// express "only if the quote has not already been issued", so using it there
+// allows two concurrent requests to issue tokens against a single payment.
 func (s *Store) UpdateMintQuoteState(id string, state ecash.QuoteState) error {
 	res, err := s.db.Exec(`UPDATE mint_quotes SET state = ? WHERE id = ?`, state, id)
 	if err != nil {
@@ -99,6 +104,26 @@ func (s *Store) UpdateMintQuoteState(id string, state ecash.QuoteState) error {
 		return ecash.ErrQuoteNotFound
 	}
 	return nil
+}
+
+// TransitionMintQuoteState moves a quote from one state to another only if it
+// is currently in the expected state, reporting whether it won.
+//
+// The compare and the write are a single statement so the database decides the
+// winner. This is what stops one paid invoice being redeemed for tokens twice
+// when requests arrive concurrently, including against separate hub processes
+// sharing the database, where an in-process lock would not help.
+func (s *Store) TransitionMintQuoteState(id string, from, to ecash.QuoteState) (bool, error) {
+	res, err := s.db.Exec(
+		`UPDATE mint_quotes SET state = ? WHERE id = ? AND state = ?`, to, id, from)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
 }
 
 // SaveSpentProofs records proofs as spent (batch insert in a transaction).

--- a/internal/tunnel/stride_test.go
+++ b/internal/tunnel/stride_test.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"context"
 	"errors"
+	"net"
 	"strings"
 	"sync"
 	"testing"
@@ -59,6 +60,31 @@ func TestSTRIDE_Spoofing_SameOperatorRunsBothHops(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "same operator") {
 		t.Fatalf("error should explain the collapsed hop, got %q", err)
+	}
+	assertNothingApplied(t, fwg, fnet)
+}
+
+func TestSTRIDE_Spoofing_BothHopsOnOneHostViaDifferentPorts(t *testing.T) {
+	// The shared-key check above is not enough. A hostile hub can run both hops
+	// on one machine with two distinct WireGuard keys, listening on two ports,
+	// and every string in the config differs. That host still terminates the
+	// outer tunnel — seeing the client's real address — and the inner tunnel,
+	// seeing the destination, which is the correlation the second hop exists to
+	// prevent. Only comparing the resolved addresses catches it.
+	fwg, fnet := newFakeWG(), newFakeNet()
+	tun := newReadyTunnel(t, fwg, fnet)
+
+	cfg := validConfig()
+	entryHost, _, err := net.SplitHostPort(cfg.Entry.Endpoint)
+	if err != nil {
+		t.Fatalf("split entry endpoint: %v", err)
+	}
+	cfg.Exit.Endpoint = net.JoinHostPort(entryHost, "51821")
+
+	if err := tun.Up(context.Background(), cfg); err == nil {
+		t.Fatal("both hops on one host must be rejected even when the keys and ports differ")
+	} else if !strings.Contains(err.Error(), "two-hop") {
+		t.Fatalf("error should explain the collapsed guarantee, got %q", err)
 	}
 	assertNothingApplied(t, fwg, fnet)
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -172,6 +172,21 @@ func (t *Tunnel) Up(ctx context.Context, cfg app.TunnelConfig) error {
 		return fmt.Errorf("exit endpoint: %w", err)
 	}
 
+	// Both hops resolving to one host defeats the point of having two.
+	//
+	// validate() rejects a shared key and an identical endpoint string, but a
+	// hostile hub can hand out two keys on one machine at different ports, or
+	// two hostnames pointing at the same address. That machine would terminate
+	// the outer tunnel, seeing the client's real address, and the inner tunnel,
+	// seeing where the traffic goes — the exact correlation the second hop
+	// exists to prevent. Comparing after resolution catches both forms.
+	//
+	// An operator with two addresses can still run both hops; that is a
+	// discovery and reputation problem, not one the client can settle here.
+	if entryIP == exitIP {
+		return fmt.Errorf("entry and exit both resolve to %s: a single host would see the client and the destination, defeating the two-hop guarantee", entryIP)
+	}
+
 	// Capture the current default route first: once the tunnel takes over the
 	// routing table there is no way to rediscover where traffic used to go.
 	gateway, iface, err := t.net.DefaultRoute()

--- a/test/loadtest/redeem_test.go
+++ b/test/loadtest/redeem_test.go
@@ -461,6 +461,20 @@ func (s *loadMemStore) UpdateMintQuoteState(id string, state ecash.QuoteState) e
 	return nil
 }
 
+func (s *loadMemStore) TransitionMintQuoteState(id string, from, to ecash.QuoteState) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	q, ok := s.quotes[id]
+	if !ok {
+		return false, ecash.ErrQuoteNotFound
+	}
+	if q.State != from {
+		return false, nil
+	}
+	q.State = to
+	return true, nil
+}
+
 func (s *loadMemStore) IsProofSpent(y string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Follow-up to #33. Six fixes, each mutation-tested: the guard was removed and the test confirmed to fail before the fix was kept.

Three of these were found by a cross-model review (security, implementation, product) run after #33 merged. Every claim was verified against the code before acting on it.

## The macOS route bug (`aa3d1ff`) — silent unencrypted traffic

`cmd/arfl-client` passed the *logical* interface names `wg-outer` / `wg-inner` to `addRoute`, but since #33 macOS assigns `utunN` and the logical name never exists at the OS level. `addRoute` only logged failures. The result on macOS: both tunnels come up, every route silently fails, and the CLI prints `✓ connected` while traffic leaves the machine unencrypted. That is the worst possible failure mode for a privacy tool — the user is told they are protected and they are not.

Routes now resolve through `wgMgr.InterfaceName()`, and `mustRoute` tears the session down and exits non-zero rather than continuing. `cleanup()` resolves the real names *before* deleting the interfaces, since deletion drops the mapping.

Still unverified on real hardware under root; tracked in #34.

## Proofs were being posted to the wrong gate (`3213502`) — would have failed live

`CashuConnector` posted `{proofs, wg_pubkey}` to `/connect`, which is the legacy RSA gate expecting `{token, wg_pubkey}`. The Cashu handler is at `/cashu-connect`. Every real connection would have been rejected.

Why the suite did not catch it: `internal/app/service_test.go` matched with `strings.HasSuffix(path, "/connect")`, which also matches `/cashu-connect`, and the E2E test hand-builds the `/cashu-connect` URL instead of going through the connector. Both doubles were more permissive than the real node. Fixed the path, tightened both fakes, and added `cashu_connector_test.go`, which registers *both* gates and asserts which one is hit.

## MintTokens issued tokens more than once per quote (`9811e11`) — free money

Read quote, check `QuotePaid`, sign, mark issued — with no lock and, unlike the proof path, no database backstop, because `UpdateMintQuoteState` was an unconditional `UPDATE ... WHERE id = ?`. A deterministic test with eight concurrent callers issued **8/8 token sets for a single Lightning payment**: seven sets given away free.

Fixed with `TransitionMintQuoteState(id, from, to) (bool, error)`, a single `UPDATE ... WHERE id = ? AND state = ?`. The database picks the winner, so the guarantee holds across multiple hub processes rather than only within one. The quote is claimed *before* signing, and released back to `QuotePaid` if signing fails, so a transient error does not consume the payment.

Same commit: the swap handler compared `switch err` by equality, but `VerifyAndMarkSpent` wraps with `%w`, so store-detected duplicates surfaced as 500 instead of 409. Now uses `errors.Is`.

Also replaced a wall-clock assertion in `TestVerifyProofsStillAllowsConcurrentReads` with an observed peak-reader count — the original would have flaked in CI under `-race`.

## Both hops could land on one host (`fd4cdbb`)

`entry` and `exit` resolving to the same IP on different ports passed validation. Two-hop routing then provides no more protection than one hop while appearing to, since a single operator sees both ends. `Up()` now rejects it, with a STRIDE test.

## Two smaller ones

`3b39dab` — the ignore patterns `arfl-hub` / `arfl-node` / `arfl-client` were unanchored, so they matched the `cmd/arfl-*` **source directories** as well as the root binaries. Already-tracked files were unaffected, which is why it went unnoticed, but any new file under those directories was silently ignored. Anchored with a leading `/`.

`3ce60f3` — dropped the deprecated `baseUrl` from the desktop `tsconfig.json` (nothing depended on it: no `paths` mapping, every import relative or a real package) rather than suppressing the warning, which would only defer the same work to TS 7. Also fixed `npm run build` deleting `frontend/dist/.gitkeep`, the file `//go:embed` needs, by adding `frontend/public/.gitkeep` — Vite copies `public/` into `dist/` on every build, so the build now restores it instead of breaking it.

## Verification

`gofmt`, `go vet`, and `go test ./... -race` clean; all three GOOS cross-compile.

| Mutation | Result |
|---|---|
| revert `MintTokens` to sign-then-mark | 8/8 issuance for one payment |
| remove `spendMu` | both atomicity tests fail, 8/8 double spends |
| widen the lock over the read-only verify | concurrency test fails (peak 1 of 4) |
| drop the unique-constraint mapping | all three store tests fail |
| remove the `entryIP == exitIP` check | STRIDE same-host test fails |
| restore `/connect` | connector test fails on the wrong gate |

## Not fixed here

Filed rather than bundled, since each is larger than this branch: #35 (no IPv6 handling anywhere — leak), #36 (`CreateInterface` is not transactional; `DeleteInterface` forgets the name even when deletion fails), #37 (desktop app requires root but GUI processes are never root, so Connect is permanently disabled from Finder), #38 (the app connect path uses direct HTTP, so the exit node learns the client IP before the tunnel exists — we already have the NIP-44 relay delivery it should be using).